### PR TITLE
fix: adjust scroll margin for anchor links to avoid fixed header overlap

### DIFF
--- a/src/page/docs/cards.mbt
+++ b/src/page/docs/cards.mbt
@@ -207,7 +207,7 @@ fn document_item(
   div(class="my-2 group \{top_rule}", [
     title,
     div(
-      class="px-4 py-2 bg-gray-100 rounded-lg relative w-full \{header_style}",
+      class="px-4 py-2 bg-gray-100 rounded-lg relative w-full scroll-mt-16 \{header_style}",
       id~,
       [signature, buttons],
     ),

--- a/src/page/docs/cards.mbt
+++ b/src/page/docs/cards.mbt
@@ -207,7 +207,7 @@ fn document_item(
   div(class="my-2 group \{top_rule}", [
     title,
     div(
-      class="px-4 py-2 bg-gray-100 rounded-lg relative w-full scroll-mt-16 \{header_style}",
+      class="px-4 py-2 bg-gray-100 rounded-lg relative w-full scroll-mt-header \{header_style}",
       id~,
       [signature, buttons],
     ),

--- a/src/tailwind.config.js
+++ b/src/tailwind.config.js
@@ -37,6 +37,9 @@ module.exports = {
       fontSize: {
         tiny: "0.7rem",
       },
+      spacing: {
+        header: "4rem", /* 64px - the navbar height */
+      },
       colors: {
         moonbit: "#cf4f89",
         mooncake: "#fbfaf5",


### PR DESCRIPTION
- Added `scroll-mt-20` to target elements to account for the fixed header height.
- Ensures anchor links scroll to the correct position without being hidden.