### PR TITLE
chore: upgrade illusory0x0/fuzzy_match

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -3,7 +3,7 @@
   "version": "0.1.1",
   "deps": {
     "rami3l/cmark": "0.3.0",
-    "illusory0x0/fuzzy_match": "0.2.2",
+    "illusory0x0/fuzzy_match": "0.2.3",
     "CAIMEOX/lazy": "0.1.0",
     "Yoorkin/prettyprinter": "0.4.3",
     "Yoorkin/rabbit-tea": "0.10.7"


### PR DESCRIPTION
Version 0.2.3 of fuzzy_match fixes language compatibility issues that prevent compilation.
`@char.` is now `Char::`

Without this change:

```
Error: [4021]
    ╭─[ .../mooncakes.io/.mooncakes/illusory0x0/fuzzy_match/src/query.mbt:25:41 ]
    │
 25 │   let case_sensitive = query.iter().any(@char.is_ascii_uppercase)
    │                                         ────────────┬───────────
    │                                                     ╰───────────── Value is_ascii_uppercase not found in package `char`.
────╯
error: failed to run build for target Js
```