### PR TITLE
feat: hide large package behind a warning by default

### DIFF
--- a/src/page/docs/cards.mbt
+++ b/src/page/docs/cards.mbt
@@ -352,6 +352,7 @@ fn[T] readme(
 
 ///|
 fn[T] document(
+  hide_large_package~ : Bool,
   readme_content? : String,
   package_data? : Status[PackageData],
   folded~ : FoldedState,
@@ -359,19 +360,51 @@ fn[T] document(
 ) -> Html[T] {
   let readme = readme(readme_content, folded~, to_msg)
   let doc_list = match package_data {
-    Some(Success({ traits, types, typealiases, values, misc, name: _ })) =>
-      [
-        ..traits.map(trait_doc(_, folded~, to_msg)),
-        ..types.map(type_doc(_, folded~, to_msg)),
-        ..typealiases.map(type_alias_doc(_, folded~, to_msg)),
-        ..values.map(value_doc(_, folded~, enable_title=true, to_msg)),
-        ..misc.map(misc_doc(_, folded~, to_msg)),
-      ]
+    Some(Success({ traits, types, typealiases, values, misc, name: _ })) => {
+      let count = traits.length() +
+        types.length() +
+        typealiases.length() +
+        values.length() +
+        misc.length()
+      if hide_large_package && count > 1000 {
+        [hidden_large_package(count, to_msg)]
+      } else {
+        [
+          ..traits.map(trait_doc(_, folded~, to_msg)),
+          ..types.map(type_doc(_, folded~, to_msg)),
+          ..typealiases.map(type_alias_doc(_, folded~, to_msg)),
+          ..values.map(value_doc(_, folded~, enable_title=true, to_msg)),
+          ..misc.map(misc_doc(_, folded~, to_msg)),
+        ]
+      }
+    }
     _ => []
   }
   div(class="contents-center flex flex-col w-full", [
     readme,
     // Ensure left and right spacing on mobile devices
     div(class="mx-4 md:mx-0", doc_list),
+  ])
+}
+
+///|
+fn[T] hidden_large_package(count : Int, to_msg : (Msg) -> T) -> Html[T] {
+  div(class="flex flex-col items-center justify-center py-12 w-full", [
+    div(
+      class="bg-mooncake border border-mooncake2 rounded-lg p-8 w-full text-center",
+      [
+        h3(class="text-xl font-semibold text-yellow-800 mb-4", [
+          text(" ⚠️ Package are too large to be shown"),
+        ]),
+        p(class="text-yellow-700 mb-6", [
+          text("This package contains over \{count} items."),
+        ]),
+        button(
+          class="px-6 py-2.5 bg-yellow-600 hover:bg-yellow-700 text-white font-medium rounded-lg transition-colors shadow-sm",
+          click=to_msg(ShowLargePackage),
+          [text("Show All Items")],
+        ),
+      ],
+    ),
   ])
 }

--- a/src/page/docs/state.mbt
+++ b/src/page/docs/state.mbt
@@ -27,6 +27,7 @@ enum Msg {
   ToggleSidebarFab
   CopyInstallCommand(String)
   CopyInstallSuccess
+  ShowLargePackage
 }
 
 ///|
@@ -49,6 +50,7 @@ struct Model {
   sidebar_fab : Bool
   search : SearchModel
   install_copied : Bool
+  hide_large_package : Bool
 }
 
 ///|
@@ -75,6 +77,7 @@ pub fn load(path : String, fragment : String?) -> (Cmd[Msg], Model) {
       search: { filter: "", results: Loading },
       search_entries: Loading,
       install_copied: false,
+      hide_large_package: true,
     },
   )
 }
@@ -219,5 +222,6 @@ pub fn update(msg : Msg, model : Model) -> (Cmd[Msg], Model) {
     CopyInstallCommand(command) =>
       (@clipboard.copy(Text(command), copied=Msg::CopyInstallSuccess), model)
     CopyInstallSuccess => (none(), { ..model, install_copied: true })
+    ShowLargePackage => (none(), { ..model, hide_large_package: false })
   }
 }

--- a/src/page/docs/view.mbt
+++ b/src/page/docs/view.mbt
@@ -38,6 +38,7 @@ pub fn[T] view(model : Model, to_msg : (Msg) -> T) -> Html[T] {
       div([
         meta,
         document(
+          hide_large_package=model.hide_large_package,
           readme_content~,
           package_data=model.package_data,
           folded=model.collapsed_docs,


### PR DESCRIPTION
Hide large packages behind a warning by default; we may implement pagination later.