### PR TITLE
[codex] remove test submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test"]
-	path = test
-	url = git@github.com:moonbitlang/mooncakes.io-test.git

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,2 @@
-[files]
-extend-exclude = ["test/**"]
-
 [default.extend-words]
 childs = "childs"

--- a/src/page/skills/pkg.generated.mbti
+++ b/src/page/skills/pkg.generated.mbti
@@ -62,3 +62,4 @@ pub(all) struct WasmEntry {
 // Type aliases
 
 // Traits
+


### PR DESCRIPTION
## Summary

- Remove the `test` git submodule from the repository.
- Delete the now-empty `.gitmodules` configuration.
- Remove the `test/**` exclusion from `_typos.toml` because the submodule no longer exists.

## Validation

- `moon check`