### PR TITLE
fix: replace deprecated Repr calls

### DIFF
--- a/src/page/build_queue/state.mbt
+++ b/src/page/build_queue/state.mbt
@@ -79,7 +79,7 @@ impl @json.FromJson for BuildData with fn from_json(json : Json, path) {
               created_at,
               finished_at: None,
             })
-          _ => raise JsonDecodeError((path, "invalid queued item: \{Repr(x)}"))
+          _ => raise JsonDecodeError((path, "invalid queued item: \{repr(x)}"))
         }
       }
       let recent_completed_items = []
@@ -104,7 +104,7 @@ impl @json.FromJson for BuildData with fn from_json(json : Json, path) {
               finished_at,
             })
           }
-          _ => raise JsonDecodeError((path, "invalid build item: \{Repr(x)}"))
+          _ => raise JsonDecodeError((path, "invalid build item: \{repr(x)}"))
         }
       }
       { queued: queued_items, recent_completed: recent_completed_items }

--- a/src/page/docs/module_index.mbt
+++ b/src/page/docs/module_index.mbt
@@ -57,7 +57,7 @@ test "dummy test to suppress unused trait implementation warning" {
     }),
     childs: @immut/sorted_map.new(),
   }
-  ignore(Repr(moduleIndex))
+  ignore(repr(moduleIndex))
 }
 
 ///|
@@ -264,7 +264,7 @@ impl @json.FromJson for Manifest with fn from_json(json : Json, path) {
       }
     }
     json =>
-      raise JsonDecodeError((path, "invalid json for Manifest: \{Repr(json)}"))
+      raise JsonDecodeError((path, "invalid json for Manifest: \{repr(json)}"))
   }
 }
 
@@ -318,7 +318,7 @@ fn decode_stype(
     }
     { "kind": "param", "name": String(name), .. } => Param(name~)
     { "name": _, "path": _, .. } => TypePath(decode_type_path(json, path))
-    _ => raise JsonDecodeError((path, "invalid json in stype: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "invalid json in stype: \{repr(json)}"))
   }
 }
 

--- a/src/page/docs/package_data.mbt
+++ b/src/page/docs/package_data.mbt
@@ -34,7 +34,7 @@ priv struct Loc {
 ///|
 test "suppress unused warnings for Loc" {
   let dummy = { path: "", file: "", line: 0, column: 0 }
-  ignore(Repr(dummy))
+  ignore(repr(dummy))
 }
 
 ///|
@@ -99,7 +99,7 @@ fn decode_loc(
       "column": Number(column, ..),
       ..
     } => { path, file, line: line.to_int(), column: column.to_int() }
-    _ => raise JsonDecodeError((path, "fail to decode loc: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "fail to decode loc: \{repr(json)}"))
   }
 }
 
@@ -115,7 +115,7 @@ fn decode_impl_doc(
       let methods = methods.map(x => decode_value_doc(x, path))
       { self_type, trait_type, methods }
     }
-    _ => raise JsonDecodeError((path, "fail to decode impl doc: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "fail to decode impl doc: \{repr(json)}"))
   }
 }
 
@@ -139,7 +139,7 @@ fn decode_type_doc(
       let loc = decode_loc(loc, path)
       { name, docstring, signature, methods, impls, loc }
     }
-    _ => raise JsonDecodeError((path, "fail to decode type doc: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "fail to decode type doc: \{repr(json)}"))
   }
 }
 
@@ -162,7 +162,7 @@ fn decode_trait_doc(
       { name, docstring, signature, impls, loc }
     }
     _ =>
-      raise JsonDecodeError((path, "fail to decode trait doc: \{Repr(json)}"))
+      raise JsonDecodeError((path, "fail to decode trait doc: \{repr(json)}"))
   }
 }
 
@@ -184,7 +184,7 @@ fn decode_typealias_doc(
     }
     _ =>
       raise JsonDecodeError(
-        (path, "fail to decode type alias doc: \{Repr(json)}"),
+        (path, "fail to decode type alias doc: \{repr(json)}"),
       )
   }
 }
@@ -203,7 +203,7 @@ fn decode_value_doc(
       ..
     } => { name, docstring, signature, loc: decode_loc(loc, path) }
     _ =>
-      raise JsonDecodeError((path, "fail to decode value doc: \{Repr(json)}"))
+      raise JsonDecodeError((path, "fail to decode value doc: \{repr(json)}"))
   }
 }
 
@@ -223,7 +223,7 @@ fn decode_misc_doc(
       let impls = impls.map(x => decode_impl_doc(x, path))
       { name, impls, methods }
     }
-    _ => raise JsonDecodeError((path, "fail to decode misc doc: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "fail to decode misc doc: \{repr(json)}"))
   }
 }
 
@@ -259,7 +259,7 @@ impl @json.FromJson for PackageData with fn from_json(json : Json, path) {
     }
     _ =>
       raise JsonDecodeError(
-        (path, "fail to decode package data: \{Repr(json)}"),
+        (path, "fail to decode package data: \{repr(json)}"),
       )
   }
 }

--- a/src/page/home/state.mbt
+++ b/src/page/home/state.mbt
@@ -416,7 +416,7 @@ impl @json.FromJson for PackageCount with fn from_json(json : Json, path) {
         total_packages: total_packages.to_int(),
         total_downloads: total_downloads.to_int(),
       }
-    _ => raise JsonDecodeError((path, "failed to parse json: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "failed to parse json: \{repr(json)}"))
   }
 }
 
@@ -471,7 +471,7 @@ fn decode_module_index(
     }
     _ =>
       raise JsonDecodeError(
-        (json_path, "unexpected item in json: \{Repr(item)}"),
+        (json_path, "unexpected item in json: \{repr(item)}"),
       )
   }
 }

--- a/src/page/skills/state.mbt
+++ b/src/page/skills/state.mbt
@@ -374,6 +374,6 @@ impl @json.FromJson for WasmEntry with fn from_json(json : Json, path) {
         created_at,
       }
     }
-    _ => raise JsonDecodeError((path, "invalid wasm entry: \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "invalid wasm entry: \{repr(json)}"))
   }
 }

--- a/src/page/user/user.mbt
+++ b/src/page/user/user.mbt
@@ -26,7 +26,7 @@ impl @json.FromJson for Profile with fn from_json(json : Json, path) {
         match x {
           { "name": String(name), "version": String(version), .. } =>
             decoded_modules.push((name, version))
-          _ => raise JsonDecodeError((path, "failed to decode \{Repr(x)}"))
+          _ => raise JsonDecodeError((path, "failed to decode \{repr(x)}"))
         }
       }
       let avatar_url = match avatar_url {
@@ -35,7 +35,7 @@ impl @json.FromJson for Profile with fn from_json(json : Json, path) {
       }
       { username, avatar_url, modules: decoded_modules }
     }
-    _ => raise JsonDecodeError((path, "failed to decode json \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "failed to decode json \{repr(json)}"))
   }
 }
 
@@ -50,12 +50,12 @@ impl @json.FromJson for CodeFrequencyResponse with fn from_json(
       for k, v in dict {
         match v {
           Number(i, ..) => result[k] = i.to_int()
-          _ => raise JsonDecodeError((path, "failed to decode \{Repr(v)}"))
+          _ => raise JsonDecodeError((path, "failed to decode \{repr(v)}"))
         }
       }
       { data: result }
     }
-    _ => raise JsonDecodeError((path, "failed to decode \{Repr(json)}"))
+    _ => raise JsonDecodeError((path, "failed to decode \{repr(json)}"))
   }
 }
 

--- a/src/util/mooncakesio_url.mbt
+++ b/src/util/mooncakesio_url.mbt
@@ -16,7 +16,7 @@ pub impl Show for MooncakesioPath with fn output(self, logger) {
     Home => logger.write_string("home:")
     User(name) => logger.write_string("user:\{name.to_owned()}")
     Docs(p, fragment~) =>
-      logger.write_string("docs: \{p.0}, fragment: \{Repr(fragment)}")
+      logger.write_string("docs: \{p.0}, fragment: \{repr(fragment)}")
     SkillsList => logger.write_string("skills:")
     SkillsDetail(entry) => logger.write_string("skills:\{entry}")
     BuildQueue => logger.write_string("build-queue")


### PR DESCRIPTION
## Summary

Replace obsolete `Repr(...)` calls with `repr(...)` so the existing source builds on the current MoonBit toolchain.

## Current toolchain

- `moon 0.1.20260713`
- `moonc v0.10.4+2cc641edf`
- `moonrun 0.1.20260713`

## Validation

- `moon fmt --check`
- `moon test --target js --serial --release`
- `moon test --target js --serial`
- `moon check --target js --deny-warn`
- `moon info --target js`
- `npm run build`
- `typos`