### PR TITLE
Prevent tables in README from overflowing into sidebar

### DIFF
--- a/src/view/markdown.mbt
+++ b/src/view/markdown.mbt
@@ -1,11 +1,11 @@
 // Copyright 2025 International Digital Economy Academy
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -360,11 +360,11 @@ fn block2html(
             }
           }
         })
-      @html.table(
-        class="w-full table-auto my-6 border-2 border-collapse border-gray-300",
-      ) <| [
-        @html.colgroup(colgroup),
-        @html.tbody(body),
+      @html.div(class="w-full overflow-x-auto") <| [
+        @html.table(class="max-width-full my-6 border-collapse border-gray-300") <| [
+          @html.colgroup(colgroup),
+          @html.tbody(body),
+        ],
       ]
     }
     LinkRefDefinition(_) => @html.nothing


### PR DESCRIPTION
Tables with long unbreakable strings currently overflow into the package metadata sidebar:

https://mooncakes.io/docs/bobzhang/openseek

<img width="1392" height="792" alt="openseek_overflow" src="https://github.com/user-attachments/assets/574a51e2-66d3-4b8a-a430-5e2e1513d8fa" />

This PR wraps rendered Markdown tables in a div to trigger a horizontal scrollbar, bringing it in line with the way GitHub handles these cases. Similarly small tables will not grow to fill the available space now, instead only taking up as much width as they need.
