### PR TITLE
fix: Fix build failure with current Moon toolchain

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -8,7 +8,7 @@ import {
   "moonbit-community/rabbita@0.15.2",
   "moonbit-community/fuzzy_match@0.2.5",
   "moonbitlang/lexer@0.3.14",
-  "moonbitlang/x@0.4.49",
+  "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.20.5",
   "hackwaly/moonback@0.8.0",
 }


### PR DESCRIPTION
This site failed to build in my environment with  `moon 0.1.20260814 (a2de5b2 2026-08-14)`.

```sh
❯ moon build
 Error: [4222]
     ╭─[ /home/antisatori/ghq/github.com/moonbitlang/mooncakes.io/.mooncakes/moonbitlang/x/time/plain_date.mbt:80:11 ]
     │
  80 │   lexscan str with longest {
     │           ─┬─
     │            ╰─── Invalid lexscan target: expected @lexbuf.Lexbuf, @lexbuf.AsyncLexbuf, or @lexbuf.StringScanner, but got StringView.
 ────╯
 Error: [4222]
     ╭─[ /home/antisatori/ghq/github.com/moonbitlang/mooncakes.io/.mooncakes/moonbitlang/x/time/plain_time.mbt:48:52 ]
     │
  48 │   let (hour, minute, second, nanosecond) = lexscan str with longest {
     │                                                    ─┬─
     │                                                     ╰─── Invalid lexscan target: expected @lexbuf.Lexbuf, @lexbuf.AsyncLexbuf, or
 @lexbuf.StringScanner, but got StringView.
 ────╯
 Failed with 0 warnings, 2 errors.
 Error: failed when building project
```

This issue is fixed by updating `moonbitlang/x` from `0.4.49` to `0.4.50`.