### PR TITLE
fix: standardize semantic buttons

### DIFF
--- a/src/page/docs/cards.mbt
+++ b/src/page/docs/cards.mbt
@@ -276,7 +276,7 @@ fn document_item(
       )
     }
   }
-  let collapse_btn : Html = div(
+  let collapse_btn : Html = button(
     class="w-8 h-8 hover:bg-gray-200 dark:hover:bg-gray-800 rounded-lg flex items-center justify-center",
     on_click=emit(ToggleDocDetail(id)),
     img(src=icon, class="size-4 ui-icon"),
@@ -301,11 +301,10 @@ fn document_item(
   let (title_view, sig_buttons, has_title) = match title {
     None => (nothing, sig_buttons_abs, false)
     Some(title) => {
-      let anchor = div(
-        class="text-gray-300 dark:text-gray-500 hover:text-gray-500 dark:hover:text-slate-400 cursor-pointer transition-colors opacity-0 group-hover/title:opacity-100 absolute -left-6 top-1/2 -translate-y-1/2",
+      let anchor = button(
+        class="text-gray-300 dark:text-gray-500 hover:text-gray-500 dark:hover:text-slate-400 transition-colors opacity-0 group-hover/title:opacity-100 absolute -left-6 top-1/2 -translate-y-1/2",
         on_click=emit(ClickAnchor(id)),
-        "#",
-      )
+      ) <| "#"
       let title_with_buttons = div(
         class="flex items-center justify-between border-b mb-4 scroll-mt-header group/title",
         id~,
@@ -488,8 +487,8 @@ fn readme(
     )
   }
   div(class="mt-4 mb-4 mx-4 md:mx-0 scroll-mt-header", id="readme") <| [
-    div(
-      class="flex items-center gap-1.5 py-1.5 px-2.5 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-900 cursor-pointer select-none w-fit",
+    button(
+      class="flex items-center gap-1.5 py-1.5 px-2.5 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-900 select-none w-fit",
       on_click=emit(ToggleDocDetail("readme")),
     ) <| [
       img(src=icon, class="size-3.5 ui-icon"),
@@ -588,8 +587,7 @@ fn hidden_large_package(count : Int, emit : (Msg) -> Cmd) -> Html {
       button(
         class="px-6 py-2.5 bg-yellow-600 hover:bg-yellow-700 text-white font-medium rounded-lg transition-colors shadow-sm",
         on_click=emit(ShowLargePackage),
-        "Show All Items",
-      ),
+      ) <| "Show All Items",
     ],
   ]
 }

--- a/src/page/docs/metainfo.mbt
+++ b/src/page/docs/metainfo.mbt
@@ -15,7 +15,7 @@
 ///|
 fn install_view(command : String, copied~ : Bool, emit : (Msg) -> Cmd) -> Html {
   let icon = if copied { @config.ok } else { @config.clipboard }
-  div(
+  button(
     class="hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800 bg-white dark:bg-zinc-900 md:shadow-xs transition-colors text-black dark:text-slate-50 text-sm px-3 p-2 font-mono border rounded outline-none flex justify-between items-center gap-2",
     on_click=emit(CopyInstallCommand(command)),
   ) <| [
@@ -74,8 +74,8 @@ fn meta_sidebar(
       if model.name == "moonbitlang/core" {
         p(class="text-gray-500 dark:text-gray-400", "Installed by default")
       } else {
-        div(
-          class="group/install hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800 bg-white dark:bg-zinc-900 transition-colors text-[13px] px-2.5 py-1.5 font-mono border rounded relative cursor-pointer",
+        button(
+          class="group/install hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800 bg-white dark:bg-zinc-900 transition-colors text-[13px] text-left px-2.5 py-1.5 font-mono border rounded relative",
           on_click=emit(CopyInstallCommand(install_cmd)),
         ) <| [
           span(class="break-all", install_cmd),

--- a/src/page/docs/sidebar.mbt
+++ b/src/page/docs/sidebar.mbt
@@ -228,16 +228,14 @@ fn sidebar(
     div(
       class="sidebar-sticky-bar flex items-center gap-1 px-1 sticky top-0 z-10 pt-3 pb-1.5 border-b border-gray-100 dark:border-zinc-800 mb-1 bg-[var(--sidebar-bg)]",
     ) <| [
-      @html.button(
+      button(
         class="text-[11px] text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 px-1.5 py-0.5 rounded hover:bg-gray-100 dark:hover:bg-zinc-900 transition-colors",
         on_click=emit(ExpandAllSidebar),
-        "Expand all",
-      ),
-      @html.button(
+      ) <| "Expand all",
+      button(
         class="text-[11px] text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 px-1.5 py-0.5 rounded hover:bg-gray-100 dark:hover:bg-zinc-900 transition-colors",
         on_click=emit(CollapseAllSidebar),
-        "Collapse all",
-      ),
+      ) <| "Collapse all",
     ],
     @tree.view(
       toggle=x => emit(ToggleSidebarItem(x)),

--- a/src/page/docs/toggle.mbt
+++ b/src/page/docs/toggle.mbt
@@ -24,7 +24,7 @@ fn card_mode_toggle(mode~ : CardMode, click~ : (CardMode) -> Cmd) -> Html {
     Expanded => (@config.reduction, Collapsed)
     Collapsed => (@config.expansion, Expanded)
   }
-  @html.button(
+  button(
     class="theme-toggle hidden md:inline-flex items-center rounded-full px-3 py-1.5 transition-colors",
     on_click=click(next_mode),
     img(class="w-4 h-4 ui-icon", src=icon),

--- a/src/page/docs/view.mbt
+++ b/src/page/docs/view.mbt
@@ -275,7 +275,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
         on_input=x => emit(SearchFilterChanged(x)),
         class="outline-none m-0 flex-grow px-4 p-2 dark:placeholder:text-slate-500",
       ),
-      div(
+      button(
         class="size-12 container hover:bg-gray-200 dark:hover:bg-gray-800 flex justify-center items-center",
         on_click=emit(ToggleSearchPanel(false)),
         img(class="ui-icon", src=@config.icon_close),
@@ -476,7 +476,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
     class="fixed inset-0 justify-center items-center z-100",
     style=["display: \{show_sidebar_dialog}"],
   ) <| [
-    div(
+    button(
       class="fixed inset-0 bg-black/40 z-10",
       style=["display: \{show_sidebar_dialog}"],
       on_click=emit(ToggleSidebarFab),
@@ -487,8 +487,8 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
       sidebar(model.sidebar_document, model.sidebar_collapsed, emit),
     ),
   ]
-  let fab : Html = @html.button(
-    class="flex lg:hidden fixed bottom-4 right-4 bg-mooncake2 text-white rounded-full shadow-lg w-12 h-12 items-center justify-center cursor-pointer hover:bg-moonbit-dark transition-all select-none",
+  let fab : Html = button(
+    class="flex lg:hidden fixed bottom-4 right-4 bg-mooncake2 text-white rounded-full shadow-lg w-12 h-12 items-center justify-center hover:bg-moonbit-dark transition-all select-none",
     on_click=emit(ToggleSidebarFab),
     img(class="size-5", src=@config.hamburger_button),
   )

--- a/src/page/home/import.mbt
+++ b/src/page/home/import.mbt
@@ -16,6 +16,9 @@
 using @html {type Html, a, div, nothing, text, input, img, h1, h2, span, p}
 
 ///|
+using @view {button}
+
+///|
 using @rabbita {type Cmd, batch, none}
 
 ///|

--- a/src/page/home/view.mbt
+++ b/src/page/home/view.mbt
@@ -457,8 +457,8 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
     ]
     let all_modules_section = div(class="pt-10 container lg:w-4/5 px-4") <| [
       div(class="flex justify-center py-2") <| [
-        div(
-          class="flex items-center gap-1.5 cursor-pointer select-none text-sm font-semibold text-yellow-700 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300 transition-colors px-6 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-900",
+        button(
+          class="flex items-center gap-1.5 select-none text-sm font-semibold text-yellow-700 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300 transition-colors px-6 py-2 rounded-md hover:bg-gray-100 dark:hover:bg-zinc-900",
           on_click=emit(ToggleAllModules),
         ) <| [
           text(

--- a/src/page/skills/import.mbt
+++ b/src/page/skills/import.mbt
@@ -2,6 +2,9 @@
 using @html {type Html, a, div, h1, h2, img, input, nothing, p, span}
 
 ///|
+using @view {button}
+
+///|
 using @rabbita {type Cmd, none}
 
 ///|

--- a/src/page/skills/view.mbt
+++ b/src/page/skills/view.mbt
@@ -219,8 +219,7 @@ fn hero_feature_card(
     ),
     p(class="mt-3 text-sm leading-6 text-gray-600 dark:text-slate-400", body),
     if action_href.is_empty() {
-      @html.button(
-        type_="button",
+      button(
         class="mt-auto inline-flex w-fit items-center gap-2 pt-4 text-xs font-semibold \{action_class}",
         on_click=emit(ScrollToSkills),
       ) <| [
@@ -289,13 +288,10 @@ fn marketplace_hero(
         div(
           class="relative mt-6 flex flex-wrap items-center justify-center gap-3",
         ) <| [
-          @html.button(
-            type_="button",
+          button(
             class="rounded-md bg-[#d79a82] px-4 py-2 text-sm font-semibold text-zinc-950 shadow-sm transition-colors hover:bg-[#e2aa94]",
             on_click=emit(ScrollToSkills),
-          ) <| [
-            span("Search Skills"),
-          ],
+          ) <| span("Search Skills"),
           a(
             href="https://www.moonbitlang.com/download/",
             class="rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm font-semibold text-gray-900 dark:text-slate-50 shadow-sm transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-50 dark:hover:bg-zinc-950",
@@ -473,11 +469,11 @@ fn entry_card(
     @config.clipboard
   }
   let copy_class = if copied {
-    "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 cursor-pointer items-center justify-center rounded border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950 transition-colors hover:border-emerald-400 dark:hover:border-emerald-700 hover:bg-emerald-100 dark:hover:bg-emerald-900 active:bg-emerald-200 dark:active:bg-emerald-800"
+    "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded border border-emerald-300 dark:border-emerald-800 bg-emerald-50 dark:bg-emerald-950 transition-colors hover:border-emerald-400 dark:hover:border-emerald-700 hover:bg-emerald-100 dark:hover:bg-emerald-900 active:bg-emerald-200 dark:active:bg-emerald-800"
   } else if failed {
-    "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 cursor-pointer items-center justify-center rounded border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950 transition-colors hover:border-red-400 dark:hover:border-red-700 hover:bg-red-100 dark:hover:bg-red-900 active:bg-red-200 dark:active:bg-red-800"
+    "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded border border-red-300 dark:border-red-800 bg-red-50 dark:bg-red-950 transition-colors hover:border-red-400 dark:hover:border-red-700 hover:bg-red-100 dark:hover:bg-red-900 active:bg-red-200 dark:active:bg-red-800"
   } else {
-    "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 cursor-pointer items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800"
+    "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800"
   }
   let copy_title = if copied {
     "Copied"
@@ -537,10 +533,9 @@ fn entry_card(
         class="block min-w-0 truncate font-mono text-[11px] leading-7 text-gray-500 dark:text-gray-400",
         run_cmd,
       ),
-      @html.button(
+      button(
         class=copy_class,
         title=copy_title,
-        type_="button",
         on_click=emit(CopyRunCommand(run_cmd)),
       ) <| [
         img(class="pointer-events-none size-3.5 ui-icon", src=copy_icon),
@@ -730,8 +725,8 @@ fn run_command_view(
     ],
     div(class="flex min-w-0 items-center gap-2 px-3 py-3") <| [
       span(class="min-w-0 flex-1 break-all font-mono text-sm", command),
-      @html.button(
-        class="inline-flex size-8 shrink-0 cursor-pointer items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800",
+      button(
+        class="inline-flex size-8 shrink-0 items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800",
         on_click=emit(CopyRunCommand(command)),
       ) <| [
         img(class="pointer-events-none size-4 ui-icon", src=icon),
@@ -980,10 +975,9 @@ fn detail_sidebar(entry : WasmEntry) -> Html {
 fn copy_skill_button(readme : Status[String], emit : (Msg) -> Cmd) -> Html {
   match readme {
     Success(content) if !content.trim().is_empty() =>
-      @html.button(
-        class="inline-flex size-7 shrink-0 cursor-pointer items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800",
+      button(
+        class="inline-flex size-7 shrink-0 items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800",
         title="Copy skill",
-        type_="button",
         on_click=emit(CopySkill(content)),
       ) <| [
         img(class="pointer-events-none size-3.5 ui-icon", src=@config.clipboard),

--- a/src/view/accordion.mbt
+++ b/src/view/accordion.mbt
@@ -32,11 +32,10 @@ pub fn accordion(
     })
     let childs = if folded { nothing } else { childs }
     div(class="w-full") <| [
-      div(
-        class="w-full rounded px-2 py-1 select-none font-semibold text-gray-700 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-gray-800 \{folded_style}",
+      button(
+        class="w-full rounded px-2 py-1 select-none text-left font-semibold text-gray-700 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-gray-800 \{folded_style}",
         on_click?,
-        title,
-      ),
+      ) <| title,
       div(class="ml-2", childs),
     ]
   })

--- a/src/view/button.mbt
+++ b/src/view/button.mbt
@@ -13,12 +13,24 @@
 // limitations under the License.
 
 ///|
-pub fn button(value : String, on_click? : Cmd) -> Html {
-  div(
-    class="hover:bg-gray-200 dark:hover:bg-gray-800 active:bg-gray-300 dark:active:bg-gray-700 active:translate-y-[3px] self-center transition-transform px-2 py-1 rounded text-sm flex select-none text-gray-800 dark:text-slate-200",
+/// Creates an appearance-neutral semantic button with the project-wide
+/// interaction defaults.
+pub fn[C : @html.IsChildren] button(
+  children : C,
+  on_click? : Cmd,
+  title? : String,
+  class? : String = "",
+  style? : Array[String] = [],
+  attrs? : @html.Attrs,
+) -> Html {
+  @html.button(
+    style~,
+    class="cursor-pointer \{class}",
+    title?,
+    type_="button",
     on_click?,
-    value,
-  )
+    attrs?,
+  ) <| children
 }
 
 ///|
@@ -27,7 +39,7 @@ pub fn icon_button(icon : String, text? : String, on_click? : Cmd) -> Html {
     None => []
     Some(value) => [@html.text(value)]
   }
-  div(
+  button(
     class="hover:bg-gray-200 dark:hover:bg-gray-800 active:bg-gray-300 dark:active:bg-gray-700 active:translate-y-[3px] transition-transform px-2 py-1 rounded text-sm select-none text-gray-800 dark:text-slate-200",
     on_click?,
   ) <| [
@@ -40,10 +52,9 @@ pub fn icon_button(icon : String, text? : String, on_click? : Cmd) -> Html {
 
 ///|
 pub fn theme_toggle(on_click? : Cmd) -> Html {
-  @html.button(
-    type_="button",
-    class="theme-toggle inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
+  button(
     on_click?,
+    class="theme-toggle inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
   ) <| [
     img(
       class="theme-toggle-icon theme-toggle-icon-computer",

--- a/src/view/collapse.mbt
+++ b/src/view/collapse.mbt
@@ -39,14 +39,14 @@ pub fn collapse(
     LeftCenter => "flex h-full w-6"
     LeftTop => "h-6 w-6 top-0 m-1"
   }
-  let button = div(
+  let toggle_button = button(
     class="absolute \{button_style} p-1 hover:bg-gray-200 dark:hover:bg-gray-800 active:bg-gray-300 dark:active:bg-gray-700",
     on_click=toggle,
     img(src=icon, class="size-4 ui-icon \{caret_style}"),
   )
   div() <| [
     div(class="relative flex items-center") <| [
-      button, header,
+      toggle_button, header,
     ],
     body,
   ]

--- a/src/view/pkg.generated.mbti
+++ b/src/view/pkg.generated.mbti
@@ -11,7 +11,7 @@ pub fn accordion(class? : String, on_click? : (String) -> @cmd.Cmd, String, Arra
 
 pub fn badge(Array[@html.Html], class? : String) -> @html.Html
 
-pub fn button(String, on_click? : @cmd.Cmd) -> @html.Html
+pub fn[C : @html.IsChildren] button(C, on_click? : @cmd.Cmd, title? : String, class? : String, style? : Array[String], attrs? : @html.Attrs) -> @html.Html
 
 pub fn code_block(String, kind~ : CodeBlockKind, transform_link? : (String) -> String) -> @html.Html
 

--- a/src/view/tree/import.mbt
+++ b/src/view/tree/import.mbt
@@ -1,11 +1,11 @@
 // Copyright 2025 International Digital Economy Academy
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,33 +13,4 @@
 // limitations under the License.
 
 ///|
-using @html {
-  type Html,
-  div,
-  text,
-  h1,
-  p,
-  pre,
-  code,
-  span,
-  nothing,
-  a,
-  h3,
-  ul,
-  img,
-}
-
-///|
 using @view {button}
-
-///|
-using @rabbita {type Cmd, batch, none}
-
-///|
-using @immut/sorted_map {type SortedMap}
-
-///|
-using @immut/sorted_set {type SortedSet}
-
-///|
-using @util {type Lazy, type Status}

--- a/src/view/tree/moon.pkg
+++ b/src/view/tree/moon.pkg
@@ -2,6 +2,7 @@ import {
   "moonbit-community/rabbita",
   "moonbitlang/core/immut/sorted_set" @immut/sorted_set,
   "moonbit-community/rabbita/html",
+  "moonbitlang/mooncakes/view",
 }
 
 supported_targets = "js+native+wasm"

--- a/src/view/tree/tree.mbt
+++ b/src/view/tree/tree.mbt
@@ -75,18 +75,17 @@ pub fn[Id : Compare] view(
           div(
             class="group/node flex items-center gap-2 px-2 py-0.5 rounded-md hover:bg-gray-200/60 dark:hover:bg-gray-800/60 active:bg-gray-200 dark:active:bg-gray-800 text-[13px] transition-colors\{font}",
           ) <| [
-            div(
-              class="shrink-0 flex-1 flex items-center gap-2 cursor-pointer",
+            button(
+              class="shrink-0 flex-1 flex items-center gap-2",
               on_click=toggle(id),
             ) <| [
               icon(id, expanded),
               @html.span(class="truncate", str),
             ],
-            div(
-              class="shrink-0 size-5 flex items-center justify-center rounded opacity-0 group-hover/node:opacity-100 hover:bg-gray-300/60 dark:hover:bg-gray-700/60 transition-opacity text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 text-xs cursor-pointer",
+            button(
+              class="shrink-0 size-5 flex items-center justify-center rounded opacity-0 group-hover/node:opacity-100 hover:bg-gray-300/60 dark:hover:bg-gray-700/60 transition-opacity text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 text-xs",
               on_click=click(id),
-              "\u{2192}",
-            ),
+            ) <| "\u{2192}",
           ],
           if expanded {
             ul(
@@ -133,8 +132,8 @@ pub fn[Id : Compare] view(
         }
 
         @html.li() <| [
-          div(
-            class="flex items-center gap-2 px-2 py-0.5 rounded-md cursor-pointer hover:bg-gray-200/60 dark:hover:bg-gray-800/60 active:bg-gray-200 dark:active:bg-gray-800 text-[13px] transition-colors\{font}",
+          button(
+            class="w-full flex items-center gap-2 px-2 py-0.5 rounded-md hover:bg-gray-200/60 dark:hover:bg-gray-800/60 active:bg-gray-200 dark:active:bg-gray-800 text-[13px] transition-colors\{font}",
             on_click=click(id),
           ) <| [
             icon(id, true),


### PR DESCRIPTION
Closes #159

This change introduces a shared semantic button primitive and exposes it as the default `button` through each package's `import.mbt`. Existing button-like actions can therefore use the shared semantic button without package qualification.

The shared button renders `<button type="button">` with a pointer cursor and each caller keeps its existing visual styles.