### PR TITLE
feat: localize frontend for Chinese site

### DIFF
--- a/src/app/main.mbt
+++ b/src/app/main.mbt
@@ -39,6 +39,7 @@ priv enum Page {
 ///|
 priv struct Model {
   theme : Theme
+  lang : @i18n.Lang
   page : Page
 }
 
@@ -167,28 +168,36 @@ fn route(url : @url.Url, model : Model, emit : Emit[Msg]) -> (Cmd, Model) {
 ///|
 #warnings("-alert_xss_vulnerable")
 fn view(emit : Emit[Msg], model : Model) -> Html {
-  let app_actions = @view.theme_toggle(on_click=emit(ToggleTheme))
+  let app_actions = @view.theme_toggle(
+    on_click=emit(ToggleTheme),
+    lang=model.lang,
+  )
+  let lang = model.lang
   let page_view = match model.page {
     Home(page_model) =>
-      @home.view(page_model, app_actions~, emit=x => emit(GotHomeMsg(x)))
+      @home.view(page_model, lang=model.lang, app_actions~, emit=x => {
+        emit(GotHomeMsg(x))
+      })
     Docs(page_model) =>
-      @docs.view(page_model, app_actions~, emit=x => emit(GotDocsMsg(x)))
+      @docs.view(page_model, lang~, app_actions~, emit=x => emit(GotDocsMsg(x)))
     User(page_model) =>
-      @user.view(page_model, app_actions~, emit=x => emit(GotUserMsg(x)))
+      @user.view(page_model, lang~, app_actions~, emit=x => emit(GotUserMsg(x)))
     BuildQueue(page_model) =>
-      @build_queue.view(page_model, app_actions~, emit=x => {
+      @build_queue.view(page_model, lang~, app_actions~, emit=x => {
         emit(GotBuildQueueMsg(x))
       })
     Skills(page_model) =>
-      @skills.view(page_model, app_actions~, emit=x => emit(GotSkillsMsg(x)))
-    NotFound => @view.not_found()
+      @skills.view(page_model, lang~, app_actions~, emit=x => {
+        emit(GotSkillsMsg(x))
+      })
+    NotFound => @view.not_found(lang)
     Redirect => @view.loading()
   }
   let html_attrs = Attrs::build()
     .data_set("theme", model.theme.resolved())
     .data_set("theme-preference", model.theme.preference.to_string())
   let bootstrap_attrs = Attrs::build().inner_html(ThemeBootstrap)
-  html(lang="en", attrs=html_attrs, [
+  html(lang=lang.html_lang(), attrs=html_attrs, [
     head([
       meta(charset="UTF-8"),
       meta(name="viewport", content="width=device-width, initial-scale=1.0"),
@@ -216,12 +225,12 @@ fn subscriptions(emit : Emit[Msg], model : Model) -> @sub.Sub {
 }
 
 ///|
-pub fn app() -> @rabbita.App {
+pub fn app(lang : @i18n.Lang) -> @rabbita.App {
   let theme : Theme = {
     preference: theme_preference_from_string(initial_theme_preference()),
     system_dark: system_prefers_dark(),
   }
-  let model = { theme, page: Redirect }
+  let model = { theme, lang, page: Redirect }
   apply_theme_now(theme)
   @rabbita.elmish(
     model=ReactiveModel(model),

--- a/src/app/moon.pkg
+++ b/src/app/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/sub",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
   "moonbitlang/mooncakes/view",
   "moonbitlang/mooncakes/page/home",

--- a/src/app/pkg.generated.mbti
+++ b/src/app/pkg.generated.mbti
@@ -3,10 +3,11 @@ package "moonbitlang/mooncakes/app"
 
 import {
   "moonbit-community/rabbita",
+  "moonbitlang/mooncakes/i18n",
 }
 
 // Values
-pub fn app() -> @rabbita.App
+pub fn app(@i18n.Lang) -> @rabbita.App
 
 // Errors
 

--- a/src/config/config.mbt
+++ b/src/config/config.mbt
@@ -1,4 +1,7 @@
 ///|
+pub const ZH_SITE : String = "pkg.moonbitlang.cn"
+
+///|
 pub let readme_icon : String = asset_url("/readme.svg")
 
 ///|
@@ -168,7 +171,7 @@ fn assets_endpoint() -> String {
 pub fn asset_url(path : String) -> String {
   let base = assets_endpoint()
   match path {
-    [.. "/", .. path] => "\{base}/\{path.to_owned()}"
+    [.. "/", .. path] => "\{base}/\{path}"
     path => "\{base}/\{path}"
   }
 }
@@ -176,9 +179,9 @@ pub fn asset_url(path : String) -> String {
 ///|
 fn api_url_with_endpoint(endpoint : String, path : String) -> String {
   match path {
-    [.. "/api/", .. path] => "\{endpoint}/\{path.to_owned()}"
+    [.. "/api/", .. path] => "\{endpoint}/\{path}"
     [.. "/api"] => endpoint
-    [.. "/", .. path] => "\{endpoint}/\{path.to_owned()}"
+    [.. "/", .. path] => "\{endpoint}/\{path}"
     path => "\{endpoint}\{path}"
   }
 }

--- a/src/config/config_wbtest.mbt
+++ b/src/config/config_wbtest.mbt
@@ -1,4 +1,9 @@
 ///|
+test "Chinese site hostname" {
+  inspect(ZH_SITE, content="pkg.moonbitlang.cn")
+}
+
+///|
 test "api url keeps same origin api path with default endpoint" {
   inspect(
     api_url_with_endpoint("/api", "/api/v0/modules"),

--- a/src/config/pkg.generated.mbti
+++ b/src/config/pkg.generated.mbti
@@ -2,6 +2,8 @@
 package "moonbitlang/mooncakes/config"
 
 // Values
+pub const ZH_SITE : String = "pkg.moonbitlang.cn"
+
 pub fn api_url(String) -> String
 
 pub fn asset_url(String) -> String

--- a/src/i18n/i18n.mbt
+++ b/src/i18n/i18n.mbt
@@ -1,0 +1,21 @@
+///|
+pub(all) enum Lang {
+  En
+  Zh
+} derive(Debug, Eq)
+
+///|
+pub fn[T] Lang::select(self : Lang, en~ : T, zh~ : T) -> T {
+  match self {
+    En => en
+    Zh => zh
+  }
+}
+
+///|
+pub fn Lang::html_lang(self : Lang) -> String {
+  match self {
+    En => "en"
+    Zh => "zh-CN"
+  }
+}

--- a/src/i18n/i18n_test.mbt
+++ b/src/i18n/i18n_test.mbt
@@ -1,0 +1,9 @@
+///|
+test "lang selects localized values and HTML language" {
+  inspect(@i18n.En.select(en="English", zh="中文"), content="English")
+  inspect(@i18n.Zh.select(en="English", zh="中文"), content="中文")
+  inspect(@i18n.En.select(en=1, zh=2), content="1")
+  inspect(@i18n.Zh.select(en=1, zh=2), content="2")
+  inspect(@i18n.En.html_lang(), content="en")
+  inspect(@i18n.Zh.html_lang(), content="zh-CN")
+}

--- a/src/i18n/moon.pkg
+++ b/src/i18n/moon.pkg
@@ -1,0 +1,5 @@
+import {
+  "moonbitlang/core/debug",
+}
+
+supported_targets = "js+native+wasm"

--- a/src/i18n/pkg.generated.mbti
+++ b/src/i18n/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/mooncakes/i18n"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) enum Lang {
+  En
+  Zh
+} derive(Eq, @debug.Debug)
+pub fn Lang::html_lang(Self) -> String
+pub fn[T] Lang::select(Self, en~ : T, zh~ : T) -> T
+
+// Type aliases
+
+// Traits

--- a/src/main/main.mbt
+++ b/src/main/main.mbt
@@ -1,5 +1,13 @@
 ///|
+extern "js" fn current_hostname() -> String =
+  #|() => String(globalThis.location?.hostname || '')
+
+///|
 #warnings("-alert_experimental")
 fn main {
-  @app.app().hydrate()
+  let lang : @i18n.Lang = match current_hostname() {
+    @config.ZH_SITE => Zh
+    _ => En
+  }
+  @app.app(lang).hydrate()
 }

--- a/src/main/moon.pkg
+++ b/src/main/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "moonbitlang/mooncakes/app",
+  "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbit-community/rabbita",
 }
 

--- a/src/page/build_queue/moon.pkg
+++ b/src/page/build_queue/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
   "moonbitlang/mooncakes/view",
 }

--- a/src/page/build_queue/pkg.generated.mbti
+++ b/src/page/build_queue/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/mooncakes/page/build_queue"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
 }
 
@@ -12,7 +13,7 @@ pub fn load(emit~ : (Msg) -> @cmd.Cmd) -> (@cmd.Cmd, Model)
 
 pub fn update(Msg, Model) -> (@cmd.Cmd, Model)
 
-pub fn view(Model, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
+pub fn view(Model, lang~ : @i18n.Lang, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
 
 // Errors
 

--- a/src/page/build_queue/view.mbt
+++ b/src/page/build_queue/view.mbt
@@ -62,7 +62,7 @@ fn status_icon(status : String) -> Html {
 }
 
 ///|
-fn build_row(item : BuildItem) -> Html {
+fn build_row(item : BuildItem, lang : @i18n.Lang) -> Html {
   let module_parts = item.module_.split("/").collect()
   let (author, name) = match module_parts {
     [author, .. rest] =>
@@ -91,7 +91,10 @@ fn build_row(item : BuildItem) -> Html {
       span(class="text-xs text-gray-300 dark:text-gray-500", "·"),
       span(
         class="text-xs text-gray-400 dark:text-slate-500",
-        @util.get_relative_time(item.finished_at.unwrap_or(item.created_at)),
+        @util.get_relative_time(
+          item.finished_at.unwrap_or(item.created_at),
+          lang,
+        ),
       ),
     ],
   ]
@@ -129,10 +132,11 @@ fn build_section(
   title : String,
   items : Status[Array[BuildItem]],
   empty_text : String,
+  lang : @i18n.Lang,
 ) -> Html {
   let content = match items {
     Loading => skeleton_build_rows(5)
-    Failed => @view.load_failed(title)
+    Failed => @view.load_failed(title, lang)
     Success(list) =>
       if list.is_empty() {
         div(
@@ -140,7 +144,10 @@ fn build_section(
           empty_text,
         )
       } else {
-        div(class="flex flex-col gap-2 animate-fade-in", list.map(build_row))
+        div(
+          class="flex flex-col gap-2 animate-fade-in",
+          list.map(item => build_row(item, lang)),
+        )
       }
   }
   div(class="mb-8") <| [
@@ -153,17 +160,33 @@ fn build_section(
 }
 
 ///|
-pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
+pub fn view(
+  model : Model,
+  lang~ : @i18n.Lang,
+  app_actions~ : Html,
+  emit~ : (Msg) -> Cmd,
+) -> Html {
   ignore(emit)
   @view.page(
-    header=@view.navbar(right=app_actions),
+    lang~,
+    header=@view.navbar(lang~, right=app_actions),
     main=div(class="container max-w-3xl mx-auto px-4 py-8") <| [
       h1(
         class="text-2xl font-bold text-gray-900 dark:text-slate-50 mb-6",
-        "Build Queue",
+        lang.select(en="Build Queue", zh="构建队列"),
       ),
-      build_section("In Queue", model.queue, "No builds in queue."),
-      build_section("Recent Builds", model.recent, "No recent builds."),
+      build_section(
+        lang.select(en="In Queue", zh="排队中"),
+        model.queue,
+        lang.select(en="No builds in queue.", zh="暂无排队任务。"),
+        lang,
+      ),
+      build_section(
+        lang.select(en="Recent Builds", zh="最近构建"),
+        model.recent,
+        lang.select(en="No recent builds.", zh="暂无最近构建。"),
+        lang,
+      ),
     ],
   )
 }

--- a/src/page/docs/cards.mbt
+++ b/src/page/docs/cards.mbt
@@ -126,6 +126,7 @@ fn impl_doc(
   folded~ : FoldedState,
   module_name~ : String,
   module_version~ : String,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let { self_type, trait_type, methods } = doc
@@ -145,9 +146,19 @@ fn impl_doc(
   ]
   let content = div(
     class="pl-4 mb-2",
-    methods.map(m => value_doc(m, folded~, module_name~, module_version~, emit)),
+    methods.map(m => {
+      value_doc(m, folded~, module_name~, module_version~, lang~, emit)
+    }),
   )
-  document_item(signature, content, collapsed=folded, id~, tight=true, emit)
+  document_item(
+    signature,
+    content,
+    collapsed=folded,
+    id~,
+    tight=true,
+    lang~,
+    emit,
+  )
 }
 
 ///|
@@ -156,18 +167,27 @@ fn type_doc(
   folded~ : FoldedState,
   module_name~ : String,
   module_version~ : String,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let { docstring, signature, methods, impls, name: _, loc } = doc
   let id = doc.get_id()
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div() <| [
-    div(class="pl-4 mb-2", @view.markdown(docstring, small_heading=true)),
+    div(class="pl-4 mb-2", @view.markdown(docstring, lang, small_heading=true)),
     ..impls.map(imp => {
-      impl_doc(imp, folded~, module_name~, module_version~, emit)
+      impl_doc(imp, folded~, module_name~, module_version~, lang~, emit)
     }),
     ..methods.map(m => {
-      value_doc(m, folded~, module_name~, module_version~, type_id=id, emit)
+      value_doc(
+        m,
+        folded~,
+        module_name~,
+        module_version~,
+        type_id=id,
+        lang~,
+        emit,
+      )
     }),
   ]
   document_item(
@@ -179,6 +199,7 @@ fn type_doc(
     loc~,
     module_name~,
     module_version~,
+    lang~,
     emit,
   )
 }
@@ -189,15 +210,16 @@ fn trait_doc(
   folded~ : FoldedState,
   module_name~ : String,
   module_version~ : String,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let { docstring, signature, impls, name: _, loc } = doc
   let id = doc.get_id()
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div() <| [
-    div(class="pl-4 mb-2", @view.markdown(docstring, small_heading=true)),
+    div(class="pl-4 mb-2", @view.markdown(docstring, lang, small_heading=true)),
     ..impls.map(imp => {
-      impl_doc(imp, folded~, module_name~, module_version~, emit)
+      impl_doc(imp, folded~, module_name~, module_version~, lang~, emit)
     }),
   ]
   document_item(
@@ -209,6 +231,7 @@ fn trait_doc(
     loc~,
     module_name~,
     module_version~,
+    lang~,
     emit,
   )
 }
@@ -219,13 +242,14 @@ fn type_alias_doc(
   folded~ : FoldedState,
   module_name~ : String,
   module_version~ : String,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let { name: _, docstring, signature, loc } = doc
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div(
     class="pl-4 mb-2",
-    @view.markdown(docstring, small_heading=true),
+    @view.markdown(docstring, lang, small_heading=true),
   )
   let id = doc.get_id()
   document_item(
@@ -237,6 +261,7 @@ fn type_alias_doc(
     loc~,
     module_name~,
     module_version~,
+    lang~,
     emit,
   )
 }
@@ -252,6 +277,7 @@ fn document_item(
   loc? : Loc,
   module_name? : String = "",
   module_version? : String = "",
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let (content_style, icon) = if collapsed.contains(id) {
@@ -272,7 +298,7 @@ fn document_item(
         href=@config.asset_url("/assets/\{path}/\{loc.file}.html#\{loc.line}"),
         class="text-xs font-semibold text-yellow-700 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300 transition-colors",
         escape=true,
-        "source",
+        lang.select(en="source", zh="源码"),
       )
     }
   }
@@ -345,6 +371,7 @@ fn value_doc(
   module_version~ : String,
   type_id? : String,
   enable_title? : Bool = false,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let { name: _, docstring, signature, loc } = doc
@@ -354,7 +381,7 @@ fn value_doc(
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div(
     class="pl-4 mb-2",
-    @view.markdown(docstring, small_heading=true),
+    @view.markdown(docstring, lang, small_heading=true),
   )
   let title = if enable_title || type_id is Some(_) { Some(id) } else { None }
   document_item(
@@ -366,6 +393,7 @@ fn value_doc(
     loc~,
     module_name~,
     module_version~,
+    lang~,
     emit,
   )
 }
@@ -376,6 +404,7 @@ fn misc_doc(
   folded~ : FoldedState,
   module_name~ : String,
   module_version~ : String,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let { name, methods, impls } = doc
@@ -392,36 +421,47 @@ fn misc_doc(
       div(
         class="bg-mooncake dark:bg-stone-900 border-mooncake2 border-opacity-50 text-yellow-800 dark:text-yellow-300 border rounded px-6 py-4 my-2",
       ) <| [
-        h3(class="text-base font-semibold", "Note"),
+        h3(class="text-base font-semibold", lang.select(en="Note", zh="提示")),
         p(class="mt-2") <| [
           text(
-            "\{name} is a built-in type. The documentation may not be complete here. You can find all methods and implementations in the ",
+            lang.select(
+              en="\{name} is a built-in type. The documentation may not be complete here. You can find all methods and implementations in the ",
+              zh="\{name} 是内置类型。此处文档可能不完整，所有方法和实现可在以下软件包中找到：",
+            ),
           ),
           a(
             href="/docs/moonbitlang/core/builtin#\{name}",
             class=package_link_class,
             "core/builtin",
           ),
-          text(" and "),
+          text(lang.select(en=" and ", zh="和")),
           a(
             href="/docs/moonbitlang/\{pkg_path}#\{name}",
             class=package_link_class,
             "core/\{name.to_lower()}",
           ),
-          text(" package."),
+          text(lang.select(en=" package.", zh="。")),
         ],
       ]
   }
   let content = div(class="ml-3 my-2") <| [
     tips,
     ..methods.map(m => {
-      value_doc(m, folded~, module_name~, module_version~, type_id=id, emit)
+      value_doc(
+        m,
+        folded~,
+        module_name~,
+        module_version~,
+        type_id=id,
+        lang~,
+        emit,
+      )
     }),
     ..impls.map(imp => {
-      impl_doc(imp, folded~, module_name~, module_version~, emit)
+      impl_doc(imp, folded~, module_name~, module_version~, lang~, emit)
     }),
   ]
-  document_item(signature, content, collapsed=folded, id~, emit)
+  document_item(signature, content, collapsed=folded, id~, lang~, emit)
 }
 
 ///|
@@ -463,6 +503,7 @@ fn readme(
   module_version~ : String,
   package_path~ : String,
   folded~ : FoldedState,
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let has_content = match content {
@@ -473,7 +514,7 @@ fn readme(
   let (body, icon) = if is_collapsed {
     (nothing, @config.section_close)
   } else if has_content {
-    let content = @view.markdown(content.unwrap(), heading_anchors=true, transform_link=href => {
+    let content = @view.markdown(content.unwrap(), lang, heading_anchors=true, transform_link=href => {
       readme_href(href, module_name, module_version, package_path)
     })
     (div(class="mt-4 mb-6", content), @config.section_open)
@@ -481,7 +522,10 @@ fn readme(
     (
       p(
         class="mt-3 mb-4 text-sm text-gray-400 dark:text-slate-500 text-center",
-        "\{package_path} does not have a README file",
+        lang.select(
+          en="\{package_path} does not have a README file",
+          zh="\{package_path} 没有 README 文件",
+        ),
       ),
       @config.section_open,
     )
@@ -511,6 +555,7 @@ fn document(
   module_name? : String = "",
   module_version? : String = "",
   package_path? : String = "",
+  lang~ : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let readme = readme(
@@ -519,6 +564,7 @@ fn document(
     module_version~,
     package_path~,
     folded~,
+    lang~,
     emit,
   )
   let doc_list = match package_data {
@@ -530,23 +576,30 @@ fn document(
         values.length() +
         misc.length()
       if hide_large_package && count > 1000 {
-        [hidden_large_package(count, emit)]
+        [hidden_large_package(count, lang, emit)]
       } else {
         [
           ..typealiases.map(ta => {
-            type_alias_doc(ta, folded~, module_name~, module_version~, emit)
+            type_alias_doc(
+              ta,
+              folded~,
+              module_name~,
+              module_version~,
+              lang~,
+              emit,
+            )
           }),
           ..traits.map(tr => {
-            trait_doc(tr, folded~, module_name~, module_version~, emit)
+            trait_doc(tr, folded~, module_name~, module_version~, lang~, emit)
           }),
           ..errors.map(err => {
-            type_doc(err, folded~, module_name~, module_version~, emit)
+            type_doc(err, folded~, module_name~, module_version~, lang~, emit)
           }),
           ..types.map(ty => {
-            type_doc(ty, folded~, module_name~, module_version~, emit)
+            type_doc(ty, folded~, module_name~, module_version~, lang~, emit)
           }),
           ..misc.map(item => {
-            misc_doc(item, folded~, module_name~, module_version~, emit)
+            misc_doc(item, folded~, module_name~, module_version~, lang~, emit)
           }),
           ..values.map(value => {
             value_doc(
@@ -555,6 +608,7 @@ fn document(
               module_name~,
               module_version~,
               enable_title=true,
+              lang~,
               emit,
             )
           }),
@@ -571,23 +625,33 @@ fn document(
 }
 
 ///|
-fn hidden_large_package(count : Int, emit : (Msg) -> Cmd) -> Html {
+fn hidden_large_package(
+  count : Int,
+  lang : @i18n.Lang,
+  emit : (Msg) -> Cmd,
+) -> Html {
   div(class="flex flex-col items-center justify-center py-12 w-full") <| [
     div(
       class="bg-mooncake dark:bg-stone-900 border border-mooncake2 rounded-lg p-8 w-full text-center",
     ) <| [
       h3(
         class="text-xl font-semibold text-yellow-800 dark:text-yellow-300 mb-4",
-        "⚠️ Package is too large to be displayed",
+        lang.select(
+          en="⚠️ Package is too large to be displayed",
+          zh="⚠️ 软件包过大，无法直接显示",
+        ),
       ),
       p(
         class="text-yellow-700 dark:text-yellow-400 mb-6",
-        "This package contains over \{count} items.",
+        lang.select(
+          en="This package contains over \{count} items.",
+          zh="此软件包包含超过 \{count} 个条目。",
+        ),
       ),
       button(
         class="px-6 py-2.5 bg-yellow-600 hover:bg-yellow-700 text-white font-medium rounded-lg transition-colors shadow-sm",
         on_click=emit(ShowLargePackage),
-      ) <| "Show All Items",
+      ) <| lang.select(en="Show All Items", zh="显示全部条目"),
     ],
   ]
 }

--- a/src/page/docs/metainfo.mbt
+++ b/src/page/docs/metainfo.mbt
@@ -62,6 +62,7 @@ fn display_url(url : String) -> String {
 ///|
 fn meta_sidebar(
   model : MetaInfo,
+  lang : @i18n.Lang,
   install_copied~ : Bool,
   emit : (Msg) -> Cmd,
 ) -> Html {
@@ -70,9 +71,12 @@ fn meta_sidebar(
   div(class="text-sm text-gray-900 dark:text-slate-50 font-medium") <| [
     // Install
     div(class="mb-4") <| [
-      p(class="font-semibold mb-1.5", "Install"),
+      p(class="font-semibold mb-1.5", lang.select(en="Install", zh="安装")),
       if model.name == "moonbitlang/core" {
-        p(class="text-gray-500 dark:text-gray-400", "Installed by default")
+        p(
+          class="text-gray-500 dark:text-gray-400",
+          lang.select(en="Installed by default", zh="默认已安装"),
+        )
       } else {
         button(
           class="group/install hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800 bg-white dark:bg-zinc-900 transition-colors text-[13px] text-left px-2.5 py-1.5 font-mono border rounded relative",
@@ -91,7 +95,7 @@ fn meta_sidebar(
         a(
           class="text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 mt-1.5 inline-block",
           href="https://download.mooncakes.io/user/\{model.name}/\{model.version}.zip",
-          "Download zip",
+          lang.select(en="Download zip", zh="下载 ZIP"),
         )
       },
     ],
@@ -155,7 +159,12 @@ fn meta_sidebar(
       if model.updated_at is Some(updated_at) {
         div(class="flex items-center gap-2") <| [
           img(class="w-4 h-4 ui-icon shrink-0", src=@config.updated),
-          text("Updated \{@util.get_relative_time(updated_at)}"),
+          text(
+            lang.select(
+              en="Updated \{@util.get_relative_time(updated_at, lang)}",
+              zh="更新于 \{@util.get_relative_time(updated_at, lang)}",
+            ),
+          ),
         ]
       } else {
         nothing
@@ -163,7 +172,12 @@ fn meta_sidebar(
       if model.downloads > 0 && model.name != "moonbitlang/core" {
         div(class="flex items-center gap-2") <| [
           img(class="w-4 h-4 ui-icon shrink-0", src=@config.download),
-          text("\{format_downloads(model.downloads)} downloads"),
+          text(
+            lang.select(
+              en="\{format_downloads(model.downloads)} downloads",
+              zh="下载 \{format_downloads(model.downloads)} 次",
+            ),
+          ),
         ]
       } else {
         nothing
@@ -174,7 +188,10 @@ fn meta_sidebar(
       nothing
     } else {
       div(class="border-t pt-3 mt-3") <| [
-        p(class="font-semibold text-[13px] mb-1.5", "Dependencies"),
+        p(
+          class="font-semibold text-[13px] mb-1.5",
+          lang.select(en="Dependencies", zh="依赖"),
+        ),
         ul(
           class="space-y-0.5",
           model.deps.map(fn(pair) {
@@ -200,6 +217,7 @@ fn meta_sidebar(
 ///|
 fn meta_info(
   model : MetaInfo,
+  lang : @i18n.Lang,
   install_copied~ : Bool,
   emit : (Msg) -> Cmd,
 ) -> Html {
@@ -230,7 +248,7 @@ fn meta_info(
       if model.name == "moonbitlang/core" {
         p(
           class="text-sm text-gray-500 dark:text-gray-400",
-          "Installed by default",
+          lang.select(en="Installed by default", zh="默认已安装"),
         )
       } else {
         install_view(
@@ -245,26 +263,35 @@ fn meta_info(
         a(
           class="text-xs text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 mt-1.5 inline-block",
           href="https://download.mooncakes.io/user/\{model.name}/\{model.version}.zip",
-          "Download zip",
+          lang.select(en="Download zip", zh="下载 ZIP"),
         )
       },
     ],
     // Meta grid
     div(class="px-6 py-3 border-t grid grid-cols-2 gap-x-4 gap-y-2 text-sm") <| [
       div() <| [
-        span(class="text-gray-400 dark:text-slate-500 text-xs", "Author"),
+        span(
+          class="text-gray-400 dark:text-slate-500 text-xs",
+          lang.select(en="Author", zh="作者"),
+        ),
         div(
           a(href="/user/\{model.author}", class="hover:underline", model.author),
         ),
       ],
       div() <| [
-        span(class="text-gray-400 dark:text-slate-500 text-xs", "Version"),
+        span(
+          class="text-gray-400 dark:text-slate-500 text-xs",
+          lang.select(en="Version", zh="版本"),
+        ),
         div(model.version),
       ],
       match model.license {
         Some(l) =>
           div() <| [
-            span(class="text-gray-400 dark:text-slate-500 text-xs", "License"),
+            span(
+              class="text-gray-400 dark:text-slate-500 text-xs",
+              lang.select(en="License", zh="许可证"),
+            ),
             div(l),
           ]
         None => nothing
@@ -274,7 +301,7 @@ fn meta_info(
           div(class="min-w-0") <| [
             span(
               class="text-gray-400 dark:text-slate-500 text-xs",
-              "Repository",
+              lang.select(en="Repository", zh="代码仓库"),
             ),
             div() <| [
               a(
@@ -292,16 +319,19 @@ fn meta_info(
         div() <| [
           span(
             class="text-gray-400 dark:text-slate-500 text-xs",
-            "Last updated",
+            lang.select(en="Last updated", zh="最后更新"),
           ),
-          div(@util.get_relative_time(updated_at)),
+          div(@util.get_relative_time(updated_at, lang)),
         ]
       } else {
         nothing
       },
       if model.downloads > 0 && model.name != "moonbitlang/core" {
         div() <| [
-          span(class="text-gray-400 dark:text-slate-500 text-xs", "Downloads"),
+          span(
+            class="text-gray-400 dark:text-slate-500 text-xs",
+            lang.select(en="Downloads", zh="下载量"),
+          ),
           div(format_downloads(model.downloads)),
         ]
       } else {
@@ -313,7 +343,10 @@ fn meta_info(
       nothing
     } else {
       div(class="px-6 py-3 border-t") <| [
-        p(class="font-semibold text-sm mb-1.5", "Dependencies"),
+        p(
+          class="font-semibold text-sm mb-1.5",
+          lang.select(en="Dependencies", zh="依赖"),
+        ),
         ul(
           class="space-y-0.5",
           model.deps.map(pair => {

--- a/src/page/docs/moon.pkg
+++ b/src/page/docs/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/core/immut/sorted_set" @immut/sorted_set,
   "moonbitlang/core/json",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/view",
   "moonbitlang/mooncakes/view/tree",
   "moonbitlang/mooncakes/util",

--- a/src/page/docs/navbar.mbt
+++ b/src/page/docs/navbar.mbt
@@ -4,6 +4,7 @@ fn navbar(
   module_path : String?,
   module_index : ModuleIndex?,
   card_mode : CardMode,
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
   app_actions~ : Html,
 ) -> Html {
@@ -16,12 +17,15 @@ fn navbar(
     on_click=emit(ToggleSearchPanel(true)),
   ) <| [
     img(class="w-4 h-4 ui-icon", src=@config.search),
-    div(class="hidden lg:block text-nowrap", "Search"),
+    div(
+      class="hidden lg:block text-nowrap",
+      lang.select(en="Search", zh="搜索"),
+    ),
   ]
   let right = div(class="flex items-center gap-2") <| [
     search_btn,
-    card_mode_toggle(mode=card_mode, click=x => emit(DocModeChanged(x))),
+    card_mode_toggle(mode=card_mode, lang~, click=x => emit(DocModeChanged(x))),
     app_actions,
   ]
-  @view.navbar(left_extra=breadcrumbs_view, right~, style=Sticky)
+  @view.navbar(lang~, left_extra=breadcrumbs_view, right~, style=Sticky)
 }

--- a/src/page/docs/pkg.generated.mbti
+++ b/src/page/docs/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/mooncakes/page/docs"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
 }
 
@@ -20,7 +21,7 @@ pub fn navigate_package(Model, @util.UnsolvedMooncakePath, String?, emit~ : (Msg
 
 pub fn update(Msg, Model, emit~ : (Msg) -> @cmd.Cmd) -> (@cmd.Cmd, Model)
 
-pub fn view(Model, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
+pub fn view(Model, lang~ : @i18n.Lang, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
 
 // Errors
 

--- a/src/page/docs/sidebar.mbt
+++ b/src/page/docs/sidebar.mbt
@@ -222,6 +222,7 @@ fn symbol_icon(kind : SymbolKind) -> Html {
 fn sidebar(
   document_index : Array[@tree.Tree[ItemTarget]],
   sidebar_state : SortedSet[ItemTarget],
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   div(class="text-gray-700 dark:text-slate-300 flex flex-col") <| [
@@ -231,11 +232,11 @@ fn sidebar(
       button(
         class="text-[11px] text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 px-1.5 py-0.5 rounded hover:bg-gray-100 dark:hover:bg-zinc-900 transition-colors",
         on_click=emit(ExpandAllSidebar),
-      ) <| "Expand all",
+      ) <| lang.select(en="Expand all", zh="全部展开"),
       button(
         class="text-[11px] text-gray-400 dark:text-slate-500 hover:text-gray-600 dark:hover:text-slate-300 px-1.5 py-0.5 rounded hover:bg-gray-100 dark:hover:bg-zinc-900 transition-colors",
         on_click=emit(CollapseAllSidebar),
-      ) <| "Collapse all",
+      ) <| lang.select(en="Collapse all", zh="全部折叠"),
     ],
     @tree.view(
       toggle=x => emit(ToggleSidebarItem(x)),
@@ -249,7 +250,11 @@ fn sidebar(
 }
 
 ///|
-fn source_files_section(files : Array[String], package_path~ : String) -> Html {
+fn source_files_section(
+  files : Array[String],
+  package_path~ : String,
+  lang~ : @i18n.Lang,
+) -> Html {
   if files.is_empty() {
     return nothing
   }
@@ -257,7 +262,7 @@ fn source_files_section(files : Array[String], package_path~ : String) -> Html {
   div(class="mx-4 md:mx-0 mt-8 mb-4") <| [
     h3(
       class="text-gray-800 dark:text-slate-200 font-semibold text-lg mb-3 border-b pb-2",
-      "Source Files",
+      lang.select(en="Source Files", zh="源文件"),
     ),
     ul(
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1",

--- a/src/page/docs/toggle.mbt
+++ b/src/page/docs/toggle.mbt
@@ -19,12 +19,20 @@ priv enum CardMode {
 }
 
 ///|
-fn card_mode_toggle(mode~ : CardMode, click~ : (CardMode) -> Cmd) -> Html {
+fn card_mode_toggle(
+  mode~ : CardMode,
+  lang~ : @i18n.Lang,
+  click~ : (CardMode) -> Cmd,
+) -> Html {
   let (icon, next_mode) = match mode {
     Expanded => (@config.reduction, Collapsed)
     Collapsed => (@config.expansion, Expanded)
   }
   button(
+    title=match mode {
+      Expanded => lang.select(en="Collapse documentation", zh="折叠文档")
+      Collapsed => lang.select(en="Expand documentation", zh="展开文档")
+    },
     class="theme-toggle hidden md:inline-flex items-center rounded-full px-3 py-1.5 transition-colors",
     on_click=click(next_mode),
     img(class="w-4 h-4 ui-icon", src=icon),

--- a/src/page/docs/view.mbt
+++ b/src/page/docs/view.mbt
@@ -101,13 +101,16 @@ fn icon_outdated() -> Html {
 }
 
 ///|
-fn build_log_view(build_log : BuildLogStatus) -> Html {
+fn build_log_view(build_log : BuildLogStatus, lang : @i18n.Lang) -> Html {
   match build_log {
     LogIdle | LogLoading => @view.loading()
     LogFailed =>
       div(
         class="docs-state-log-note docs-state-log-note-error text-red-700 dark:text-red-300",
-        "Failed to load build log.",
+        lang.select(
+          en="Failed to load build log.",
+          zh="无法加载构建日志。",
+        ),
       )
     LogSuccess(log) => pre(class="docs-state-log-pre", code(log))
   }
@@ -117,6 +120,7 @@ fn build_log_view(build_log : BuildLogStatus) -> Html {
 fn build_log_panel(
   build_log_open : Bool,
   build_log : BuildLogStatus,
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
   footer? : Html = nothing,
 ) -> Html {
@@ -134,7 +138,7 @@ fn build_log_panel(
     ) <| [
       p(
         class="docs-state-log-title text-gray-900 dark:text-slate-50",
-        "Build log",
+        lang.select(en="Build log", zh="构建日志"),
       ),
       img(src=toggle_icon, class="size-4 ui-icon shrink-0"),
     ],
@@ -144,7 +148,7 @@ fn build_log_panel(
         _ => true
       }
       div(class="docs-state-log-body") <| [
-        build_log_view(build_log),
+        build_log_view(build_log, lang),
         if show_footer {
           footer
         } else {
@@ -161,35 +165,51 @@ fn build_log_panel(
 fn failed_docs_notice(
   build_log_open : Bool,
   build_log : BuildLogStatus,
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   div(class="flex flex-col items-center justify-center py-16 text-center") <| [
     icon_failed(),
-    p(class="mt-3 text-base text-gray-500 dark:text-gray-400", "Build failed"),
+    p(
+      class="mt-3 text-base text-gray-500 dark:text-gray-400",
+      lang.select(en="Build failed", zh="构建失败"),
+    ),
     p(
       class="mt-1 text-sm text-gray-400 dark:text-slate-500",
-      "Documentation failed to generate for this version.",
+      lang.select(
+        en="Documentation failed to generate for this version.",
+        zh="此版本的文档生成失败。",
+      ),
     ),
     p(
       class="mt-2 text-sm text-gray-400 dark:text-slate-500",
-      "The package is ready to install and use as a dependency.",
+      lang.select(
+        en="The package is ready to install and use as a dependency.",
+        zh="该软件包仍可安装并作为依赖使用。",
+      ),
     ),
     div(class="mt-8 w-full text-left") <| [
       build_log_panel(
         build_log_open,
         build_log,
+        lang,
         emit,
         footer=p(
           class="docs-state-summary text-gray-500 dark:text-slate-400",
           style=["margin-top: 0.75rem"],
         ) <| [
-          text("If this seems wrong, "),
+          text(
+            lang.select(
+              en="If this seems wrong, ",
+              zh="如果这看起来不对，请",
+            ),
+          ),
           a(
             class="text-blue-500 dark:text-sky-300 hover:text-blue-700 dark:hover:text-blue-300 transition-colors",
             href="https://github.com/moonbitlang/mooncakes.io/issues/new",
-            "report it",
+            lang.select(en="report it", zh="反馈问题"),
           ),
-          text("."),
+          text(lang.select(en=".", zh="。")),
         ],
       ),
     ],
@@ -197,49 +217,68 @@ fn failed_docs_notice(
 }
 
 ///|
-fn queued_docs_notice() -> Html {
+fn queued_docs_notice(lang : @i18n.Lang) -> Html {
   div(class="flex flex-col items-center justify-center py-16 text-center") <| [
     icon_queued(),
     p(
       class="mt-3 text-base text-gray-500 dark:text-gray-400",
-      "Building documentation...",
+      lang.select(en="Building documentation...", zh="正在构建文档…"),
     ),
     p(class="mt-1 text-sm text-gray-400 dark:text-slate-500") <| [
-      text("This may take a few minutes. "),
+      text(
+        lang.select(
+          en="This may take a few minutes. ",
+          zh="这可能需要几分钟。",
+        ),
+      ),
       a(
         href="/build-queue",
         class="text-blue-500 dark:text-sky-300 hover:text-blue-700 dark:hover:text-blue-300 transition-colors",
-        "View build queue",
+        lang.select(en="View build queue", zh="查看构建队列"),
       ),
     ],
     p(
       class="mt-2 text-sm text-gray-400 dark:text-slate-500",
-      "The package is ready to install and use as a dependency.",
+      lang.select(
+        en="The package is ready to install and use as a dependency.",
+        zh="该软件包仍可安装并作为依赖使用。",
+      ),
     ),
   ]
 }
 
 ///|
-fn outdated_docs_notice() -> Html {
+fn outdated_docs_notice(lang : @i18n.Lang) -> Html {
   div(class="flex flex-col items-center justify-center py-16 text-center") <| [
     icon_outdated(),
     p(
       class="mt-3 text-base text-gray-500 dark:text-gray-400",
-      "No documentation available",
+      lang.select(en="No documentation available", zh="暂无文档"),
     ),
     p(
       class="mt-1 text-sm text-gray-400 dark:text-slate-500",
-      "This version was published before doc generation was available.",
+      lang.select(
+        en="This version was published before doc generation was available.",
+        zh="此版本发布时尚未提供文档生成功能。",
+      ),
     ),
     p(
       class="mt-2 text-sm text-gray-400 dark:text-slate-500",
-      "The package is ready to install and use as a dependency.",
+      lang.select(
+        en="The package is ready to install and use as a dependency.",
+        zh="该软件包仍可安装并作为依赖使用。",
+      ),
     ),
   ]
 }
 
 ///|
-pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
+pub fn view(
+  model : Model,
+  lang~ : @i18n.Lang,
+  app_actions~ : Html,
+  emit~ : (Msg) -> Cmd,
+) -> Html {
   let module_index = match model.module_index {
     Success(module_index) => Some(module_index)
     _ => None
@@ -257,6 +296,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
     nav_module_path,
     module_index,
     model.collapsed_docs.card_mode,
+    lang,
     emit,
     app_actions~,
   )
@@ -271,7 +311,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
       @html.input(
         input_type=Text,
         value=search.filter,
-        placeholder="search...",
+        placeholder=lang.select(en="search...", zh="搜索…"),
         on_input=x => emit(SearchFilterChanged(x)),
         class="outline-none m-0 flex-grow px-4 p-2 dark:placeholder:text-slate-500",
       ),
@@ -283,7 +323,8 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
     ],
     match search.results {
       Loading => nothing
-      Failed => text("load indices failed")
+      Failed =>
+        text(lang.select(en="Failed to load indices", zh="加载索引失败"))
       Success(results) =>
         @html.ul(
           class="overflow-y-auto flex-grow",
@@ -317,7 +358,17 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
                 ),
                 span(
                   class="font-thin text-tiny lg:text-base \{color}",
-                  x.entry.kind,
+                  lang.select(
+                    en=x.entry.kind,
+                    zh=match x.entry.kind {
+                      "Package" => "软件包"
+                      "Trait" => "特征"
+                      "Type" => "类型"
+                      "Method" => "方法"
+                      "Value" => "值"
+                      kind => kind
+                    },
+                  ),
                 ),
               ],
             ]
@@ -344,7 +395,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
           ),
         ],
       ],
-      @view.footer(),
+      @view.footer(lang),
     ]
   }
   let path_str = resolved.package_path()
@@ -367,7 +418,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
       Some(meta) =>
         div(
           class="xl:hidden",
-          meta_info(meta, install_copied=model.install_copied, emit),
+          meta_info(meta, lang, install_copied=model.install_copied, emit),
         )
       None => nothing
     }
@@ -379,7 +430,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
     Some(meta) =>
       div(
         class="animate-fade-in",
-        meta_sidebar(meta, install_copied=model.install_copied, emit),
+        meta_sidebar(meta, lang, install_copied=model.install_copied, emit),
       )
     None =>
       if model.module_meta is Loading {
@@ -397,7 +448,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
       if docs_loaded {
         nothing
       } else {
-        @view.document_not_available(path_str)
+        @view.document_not_available(path_str, lang)
       }
     (Success(_), Success(meta)) =>
       match meta.build_status {
@@ -405,23 +456,28 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
           if docs_loaded {
             nothing
           } else {
-            queued_docs_notice()
+            queued_docs_notice(lang)
           }
         Some(BuildFailed) =>
           if docs_loaded {
             nothing
           } else {
-            failed_docs_notice(model.build_log_open, model.build_log, emit)
+            failed_docs_notice(
+              model.build_log_open,
+              model.build_log,
+              lang,
+              emit,
+            )
           }
-        None => if docs_loaded { nothing } else { outdated_docs_notice() }
+        None => if docs_loaded { nothing } else { outdated_docs_notice(lang) }
         Some(BuildSuccess) | Some(BuildLegacy) =>
           match (model.readme_content, model.module_index, model.package_data) {
             (Failed, _, _) | (_, Failed, _) =>
-              @view.document_not_available(path_str)
+              @view.document_not_available(path_str, lang)
             (_, _, Failed) =>
               match model.manifest {
                 Success(manifest) if manifest.has_package =>
-                  @view.document_not_available(path_str)
+                  @view.document_not_available(path_str, lang)
                 _ => nothing
               }
             _ => nothing
@@ -447,12 +503,13 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
             module_name~,
             module_version~,
             package_path=path_str,
+            lang~,
             emit,
           ),
         ]
       _ => nothing
     }
-    let src = source_files_section(model.source_files, package_path~)
+    let src = source_files_section(model.source_files, package_path~, lang~)
     (doc, src)
   } else {
     let skeleton = match model.module_meta {
@@ -484,7 +541,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
     ),
     div(
       class="bg-zinc-50 dark:bg-zinc-950 w-3/4 h-3/4 overflow-y-auto rounded px-4 pb-4 shadow-lg z-20",
-      sidebar(model.sidebar_document, model.sidebar_collapsed, emit),
+      sidebar(model.sidebar_document, model.sidebar_collapsed, lang, emit),
     ),
   ]
   let fab : Html = button(
@@ -508,7 +565,12 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
             } else {
               div(
                 class="animate-fade-in",
-                sidebar(model.sidebar_document, model.sidebar_collapsed, emit),
+                sidebar(
+                  model.sidebar_document,
+                  model.sidebar_collapsed,
+                  lang,
+                  emit,
+                ),
               )
             },
           ],
@@ -522,6 +584,6 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
         ),
       ],
     ],
-    @view.footer(),
+    @view.footer(lang),
   ]
 }

--- a/src/page/home/import.mbt
+++ b/src/page/home/import.mbt
@@ -13,7 +13,20 @@
 // limitations under the License.
 
 ///|
-using @html {type Html, a, div, nothing, text, input, img, h1, h2, span, p}
+using @html {
+  type Attrs,
+  type Html,
+  a,
+  div,
+  nothing,
+  text,
+  input,
+  img,
+  h1,
+  h2,
+  span,
+  p,
+}
 
 ///|
 using @view {button}

--- a/src/page/home/moon.pkg
+++ b/src/page/home/moon.pkg
@@ -6,6 +6,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/view",
   "moonbitlang/mooncakes/util",
   "moonbit-community/fuzzy_match",

--- a/src/page/home/pkg.generated.mbti
+++ b/src/page/home/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/mooncakes/page/home"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
 }
 
@@ -14,7 +15,7 @@ pub fn load(emit~ : (Msg) -> @cmd.Cmd) -> (@cmd.Cmd, Model)
 
 pub fn update(Msg, Model, emit~ : (Msg) -> @cmd.Cmd) -> (@cmd.Cmd, Model)
 
-pub fn view(Model, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
+pub fn view(Model, lang~ : @i18n.Lang, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
 
 // Errors
 

--- a/src/page/home/view.mbt
+++ b/src/page/home/view.mbt
@@ -22,7 +22,7 @@ fn versioned_path(mod : ModuleIndex) -> String {
 }
 
 ///|
-fn simple_module_card(mod : ModuleIndex) -> Html {
+fn simple_module_card(mod : ModuleIndex, lang : @i18n.Lang) -> Html {
   let href = "/docs/\{versioned_path(mod)}"
   div(
     class="h-24 lg:h-30 flex-nowrap bg-white dark:bg-zinc-900 text-gray-700 dark:text-slate-300 select-none py-3 px-4 flex outline outline-transparent flex-col border-gray-200 dark:border-zinc-800 border-b lg:hover:outline-mooncake2 lg:hover:border-transparent lg:hover:shadow-md border rounded-md transition-shadow",
@@ -50,7 +50,7 @@ fn simple_module_card(mod : ModuleIndex) -> Html {
       div(class="flex items-baseline gap-2") <| [
         if mod.is_new {
           @view.badge(class="bg-gray-700 dark:bg-gray-700 text-white", [
-            text("NEW"),
+            text(lang.select(en="NEW", zh="新")),
           ])
         } else {
           nothing
@@ -58,7 +58,9 @@ fn simple_module_card(mod : ModuleIndex) -> Html {
         span(class="text-xs text-gray-500 dark:text-gray-400", mod.version),
         p(
           class="text-xs flex-1 text-right text-gray-500 dark:text-gray-400",
-          mod.created_at.map(@util.get_relative_time).unwrap_or(""),
+          mod.created_at
+          .map(date => @util.get_relative_time(date, lang))
+          .unwrap_or(""),
         ),
       ],
     ],
@@ -66,7 +68,7 @@ fn simple_module_card(mod : ModuleIndex) -> Html {
 }
 
 ///|
-fn module_card(mod : ModuleIndex) -> Html {
+fn module_card(mod : ModuleIndex, lang : @i18n.Lang) -> Html {
   let keywords = match mod.keywords {
     None => nothing
     Some(keywords) =>
@@ -89,7 +91,7 @@ fn module_card(mod : ModuleIndex) -> Html {
       )
   }
   let time = match mod.created_at {
-    Some(t) => p(@util.get_relative_time(t))
+    Some(t) => p(@util.get_relative_time(t, lang))
     None => nothing
   }
   div(
@@ -122,7 +124,7 @@ fn module_card(mod : ModuleIndex) -> Html {
 }
 
 ///|
-fn pinned() -> Html {
+fn pinned(lang : @i18n.Lang) -> Html {
   let pinned = [
     {
       author: "moonbitlang",
@@ -131,7 +133,10 @@ fn pinned() -> Html {
       version: "",
       keywords: None,
       description: Some(
-        "Always up-to-date documentation for the MoonBit standard library API.",
+        lang.select(
+          en="Always up-to-date documentation for the MoonBit standard library API.",
+          zh="始终与 MoonBit 标准库 API 保持同步的文档。",
+        ),
       ),
       created_at: None,
       is_new: false,
@@ -143,7 +148,10 @@ fn pinned() -> Html {
       version: "",
       keywords: None,
       description: Some(
-        "Asynchronous programming library for MoonBit. Including fs, http, io, and more.",
+        lang.select(
+          en="Asynchronous programming library for MoonBit. Including fs, http, io, and more.",
+          zh="MoonBit 异步编程库，包含文件系统、HTTP、I/O 等功能。",
+        ),
       ),
       created_at: None,
       is_new: false,
@@ -154,7 +162,12 @@ fn pinned() -> Html {
       path: "moonbitlang/x",
       version: "",
       keywords: None,
-      description: Some("Experimental and extended libraries for MoonBit."),
+      description: Some(
+        lang.select(
+          en="Experimental and extended libraries for MoonBit.",
+          zh="MoonBit 的实验性扩展库。",
+        ),
+      ),
       created_at: None,
       is_new: false,
     },
@@ -162,20 +175,28 @@ fn pinned() -> Html {
   div(class="container lg:w-4/5 px-4 mt-4 mb-6") <| [
     h1(
       class="py-2 text-sm font-bold text-gray-600 dark:text-slate-400",
-      "Pinned modules",
+      lang.select(en="Pinned modules", zh="精选模块"),
     ),
     div(
       class="grid grid-cols-1 lg:grid-cols-3 gap-2",
-      pinned.map(fn(m) { compact_module_card(m) }),
+      pinned.map(fn(m) { compact_module_card(m, lang) }),
     ),
   ]
 }
 
 ///|
-fn compact_module_card(mod : ModuleIndex, show_time? : Bool = false) -> Html {
+fn compact_module_card(
+  mod : ModuleIndex,
+  lang : @i18n.Lang,
+  show_time? : Bool = false,
+) -> Html {
   let href = "/docs/\{versioned_path(mod)}"
   let badge = if show_time {
-    text(mod.created_at.map(@util.get_relative_time).unwrap_or(""))
+    text(
+      mod.created_at
+      .map(date => @util.get_relative_time(date, lang))
+      .unwrap_or(""),
+    )
   } else {
     text(mod.version)
   }
@@ -209,6 +230,7 @@ fn compact_module_card(mod : ModuleIndex, show_time? : Bool = false) -> Html {
 fn module_list_column(
   title : String,
   modules : Array[ModuleIndex],
+  lang : @i18n.Lang,
   show_time? : Bool = false,
 ) -> Html {
   div(class="flex flex-col gap-2") <| [
@@ -216,7 +238,7 @@ fn module_list_column(
     ..modules
     .iter()
     .take(12)
-    .map(fn(m) { compact_module_card(m, show_time~) })
+    .map(fn(m) { compact_module_card(m, lang, show_time~) })
     .collect(),
   ]
 }
@@ -226,18 +248,36 @@ fn highlights_section(
   recent : Array[ModuleIndex],
   new_published : Array[ModuleIndex],
   popular : Array[ModuleIndex],
+  lang : @i18n.Lang,
 ) -> Html {
   div(class="container lg:w-4/5 px-4 animate-fade-in") <| [
     div(class="grid grid-cols-1 lg:grid-cols-3 gap-4") <| [
-      module_list_column("Recently updated", recent, show_time=true),
-      module_list_column("Newly published", new_published, show_time=true),
-      module_list_column("Most downloaded", popular),
+      module_list_column(
+        lang.select(en="Recently updated", zh="最近更新"),
+        recent,
+        lang,
+        show_time=true,
+      ),
+      module_list_column(
+        lang.select(en="Newly published", zh="最新发布"),
+        new_published,
+        lang,
+        show_time=true,
+      ),
+      module_list_column(
+        lang.select(en="Most downloaded", zh="下载最多"),
+        popular,
+        lang,
+      ),
     ],
   ]
 }
 
 ///|
-fn all_modules(modules : Map[Char, Array[ModuleIndex]]) -> Html {
+fn all_modules(
+  modules : Map[Char, Array[ModuleIndex]],
+  lang : @i18n.Lang,
+) -> Html {
   let all_modules = modules
     .iter2()
     .to_array()
@@ -251,7 +291,7 @@ fn all_modules(modules : Map[Char, Array[ModuleIndex]]) -> Html {
     })
     .map(fn(x) {
       let (key, value) = x
-      let modules = value.map(simple_module_card)
+      let modules = value.map(mod_item => simple_module_card(mod_item, lang))
       div(class="pt-2") <| [
         h1(
           class="py-2 text-sm font-bold text-gray-600 dark:text-slate-400",
@@ -267,13 +307,13 @@ fn all_modules(modules : Map[Char, Array[ModuleIndex]]) -> Html {
 }
 
 ///|
-fn search_result(mods : Array[ModuleIndex]) -> Html {
-  let module_cards = mods.map(module_card)
+fn search_result(mods : Array[ModuleIndex], lang : @i18n.Lang) -> Html {
+  let module_cards = mods.map(mod_item => module_card(mod_item, lang))
   div() <| [
     div(class="container lg:w-4/5 px-4") <| [
       h1(
         class="p-4 text-sm font-bold text-gray-400 dark:text-slate-500 lg:border-0",
-        "SEARCH RESULT",
+        lang.select(en="SEARCH RESULT", zh="搜索结果"),
       ),
       div(class="grid grid-cols-1 gap-2", module_cards),
     ],
@@ -307,6 +347,7 @@ fn banner(
   total_modules~ : Int,
   total_packages~ : Int,
   total_downloads~ : Int,
+  lang~ : @i18n.Lang,
 ) -> Html {
   fn button(value, target, color) {
     a(
@@ -363,6 +404,12 @@ fn banner(
     ]
   }
 
+  let community_heading_class = if lang is Zh {
+    "text-2xl font-semibold lg:text-3xl lg:mt-0"
+  } else {
+    "text-3xl font-semibold lg:text-4xl lg:mt-0"
+  }
+
   div(
     class="container lg:w-4/5 xl:w-3/4 px-5 sm:px-6 flex flex-col gap-3 lg:flex-row items-center justify-start lg:justify-center lg:gap-6 xl:gap-12 lg:py-8",
   ) <| [
@@ -370,34 +417,58 @@ fn banner(
       class="text-center lg:text-left mx-4 bg-bottom rounded-xl flex-col lg:max-w-[450px] xl:max-w-[520px] mt-4 lg:mt-0",
     ) <| [
       div(class="text-slate-700 dark:text-slate-300 home-hero-copy") <| [
-        h1(class="text-2xl font-semibold lg:text-4xl", "The Package Registry"),
-        h1(class="text-3xl font-semibold lg:text-4xl lg:mt-0") <| [
-          text("for"),
+        h1(
+          class="text-2xl font-semibold lg:text-4xl",
+          lang.select(en="The Package Registry", zh="软件包仓库"),
+        ),
+        h1(class=community_heading_class) <| [
+          text(lang.select(en="for", zh="面向")),
           span(class="text-moonbit font-extrabold", " MoonBit "),
-          text("community"),
+          text(lang.select(en="community", zh="社区")),
         ],
         h2(
           class="hidden lg:block text-xl mt-4 text-zinc-500 dark:text-gray-400 gap-1",
-          "Browse, search and share package and documentation",
+          lang.select(
+            en="Browse, search and share package and documentation",
+            zh="浏览、搜索和分享软件包及其文档",
+          ),
         ),
       ],
       div(
         class="hidden sm:flex mt-2 lg:mt-8 gap-4 justify-center lg:justify-start",
       ) <| [
         button(
-          "Getting Started", "https://docs.moonbitlang.com/en/latest/toolchain/moon/package-manage-tour.html",
+          lang.select(en="Getting Started", zh="快速开始"),
+          "https://docs.moonbitlang.com/en/latest/toolchain/moon/package-manage-tour.html",
           "bg-yellow-600 text-white",
         ),
         button(
-          "Install Moon", "https://www.moonbitlang.com/download/", "bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-slate-200",
+          lang.select(en="Install Moon", zh="安装 Moon"),
+          "https://www.moonbitlang.com/download/",
+          "bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-slate-200",
         ),
       ],
     ],
     div(class="home-hero-media flex relative w-full mt-2 lg:mt-0 sm:w-4/5") <| [
       div(class="flex w-full flex-row gap-3 z-10 lg:hidden select-none") <| [
-        stat_card("Packages", total_packages, false, None),
-        stat_card("Modules", total_modules, false, None),
-        stat_card("Downloads", total_downloads, false, None),
+        stat_card(
+          lang.select(en="Packages", zh="软件包"),
+          total_packages,
+          false,
+          None,
+        ),
+        stat_card(
+          lang.select(en="Modules", zh="模块"),
+          total_modules,
+          false,
+          None,
+        ),
+        stat_card(
+          lang.select(en="Downloads", zh="下载量"),
+          total_downloads,
+          false,
+          None,
+        ),
       ],
       div(class="home-hero-illustration hidden lg:block select-none") <| [
         img(
@@ -406,10 +477,20 @@ fn banner(
         ),
         div(class="home-stat-bubble-layer") <| [
           stat_bubble(
-            "Downloads", total_downloads, "home-stat-bubble-downloads",
+            lang.select(en="Downloads", zh="下载量"),
+            total_downloads,
+            "home-stat-bubble-downloads",
           ),
-          stat_bubble("Modules", total_modules, "home-stat-bubble-modules"),
-          stat_bubble("Packages", total_packages, "home-stat-bubble-packages"),
+          stat_bubble(
+            lang.select(en="Modules", zh="模块"),
+            total_modules,
+            "home-stat-bubble-modules",
+          ),
+          stat_bubble(
+            lang.select(en="Packages", zh="软件包"),
+            total_packages,
+            "home-stat-bubble-packages",
+          ),
         ],
       ],
     ],
@@ -417,12 +498,43 @@ fn banner(
 }
 
 ///|
-pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
+fn site_switch_href(lang : @i18n.Lang) -> String {
+  match lang {
+    En => "https://\{@config.ZH_SITE}/"
+    Zh => "https://mooncakes.io/"
+  }
+}
+
+///|
+fn site_switch(lang : @i18n.Lang) -> Html {
+  let label = lang.select(en="中文站", zh="全球站")
+  a(
+    href=site_switch_href(lang),
+    escape=true,
+    "\{label} ↗",
+    class="shrink-0 px-1 py-1 text-xs sm:text-sm font-medium text-gray-500 dark:text-slate-400 hover:text-yellow-700 dark:hover:text-yellow-400 transition-colors",
+    attrs=Attrs::build().aria_label(
+      lang.select(en="Switch to Chinese site", zh="切换到全球站"),
+    ),
+  )
+}
+
+///|
+pub fn view(
+  model : Model,
+  lang~ : @i18n.Lang,
+  app_actions~ : Html,
+  emit~ : (Msg) -> Cmd,
+) -> Html {
   let module_list = if model.filter == "" {
-    let pinned_modules = pinned()
+    let pinned_modules = pinned(lang)
     let highlights = match model.highlights {
-      Success(h) => highlights_section(h.recent, h.new_modules, h.popular)
-      Failed => @view.load_failed("recently updated modules")
+      Success(h) => highlights_section(h.recent, h.new_modules, h.popular, lang)
+      Failed =>
+        @view.load_failed(
+          lang.select(en="recently updated modules", zh="最近更新的模块"),
+          lang,
+        )
       Loading =>
         div(
           class="container lg:w-4/5 px-4",
@@ -463,9 +575,9 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
         ) <| [
           text(
             if model.show_all_modules {
-              "Hide modules"
+              lang.select(en="Hide modules", zh="收起模块")
             } else {
-              "Show more modules"
+              lang.select(en="Show more modules", zh="显示更多模块")
             },
           ),
           if model.show_all_modules {
@@ -478,8 +590,12 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
       if model.show_all_modules {
         match model.all_modules {
           Idle | Loading => @view.skeleton_module_cards(9)
-          Failed => @view.load_failed("module indices")
-          Success(xs) => all_modules(xs.indices)
+          Failed =>
+            @view.load_failed(
+              lang.select(en="module indices", zh="模块索引"),
+              lang,
+            )
+          Success(xs) => all_modules(xs.indices, lang)
         }
       } else {
         nothing
@@ -491,8 +607,12 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
   } else {
     match model.all_modules {
       Idle | Loading => @view.loading()
-      Failed => @view.load_failed("module indices")
-      Success(_) => search_result(model.filtered_modules)
+      Failed =>
+        @view.load_failed(
+          lang.select(en="module indices", zh="模块索引"),
+          lang,
+        )
+      Success(_) => search_result(model.filtered_modules, lang)
     }
   }
   let banner = if model.filter == "" {
@@ -500,23 +620,28 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
       total_modules=model.showing_modules,
       total_downloads=model.showing_downloads,
       total_packages=model.showing_packages,
+      lang~,
     )
   } else {
     nothing
   }
   let hero = div(class="home-hero-shell pb-2 sm:pb-8") <| [
     @view.navbar(
+      lang~,
       style=Fusion,
       middle=input(
         input_type=Text,
         value=model.filter,
-        placeholder="Search modules ...",
+        placeholder=lang.select(en="Search modules ...", zh="搜索模块…"),
         class="border rounded-full my-1 lg:my-0 w-full lg:w-[380px] text-sm lg:text-base px-4 py-2 bg-white/90 dark:bg-zinc-900/90 shadow-sm shadow-black/5 focus:border-mooncake2 focus:shadow-2xl outline-none transition-colors dark:placeholder:text-slate-500",
         on_input=x => emit(FilterChanged(x)),
       ),
-      right=app_actions,
+      right=div(class="flex items-center gap-2", [
+        site_switch(lang),
+        app_actions,
+      ]),
     ),
     div(class="hero-banner", banner),
   ]
-  @view.page(header=hero, main=div(class="w-full", module_list))
+  @view.page(lang~, header=hero, main=div(class="w-full", module_list))
 }

--- a/src/page/home/view_wbtest.mbt
+++ b/src/page/home/view_wbtest.mbt
@@ -1,0 +1,5 @@
+///|
+test "site switch targets fixed site roots" {
+  inspect(site_switch_href(@i18n.En), content="https://pkg.moonbitlang.cn/")
+  inspect(site_switch_href(@i18n.Zh), content="https://mooncakes.io/")
+}

--- a/src/page/skills/moon.pkg
+++ b/src/page/skills/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
   "moonbitlang/mooncakes/view",
 }

--- a/src/page/skills/pkg.generated.mbti
+++ b/src/page/skills/pkg.generated.mbti
@@ -5,6 +5,7 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
 }
 
@@ -17,7 +18,7 @@ pub fn subscriptions(Model, emit~ : (Msg) -> @cmd.Cmd) -> @sub.Sub
 
 pub fn update(Msg, Model, emit~ : (Msg) -> @cmd.Cmd) -> (@cmd.Cmd, Model)
 
-pub fn view(Model, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
+pub fn view(Model, lang~ : @i18n.Lang, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
 
 // Errors
 

--- a/src/page/skills/view.mbt
+++ b/src/page/skills/view.mbt
@@ -89,6 +89,7 @@ fn runwasm_showcase(
   entries : Status[Array[WasmEntry]],
   showcase_index : Int,
   showcase_chars : Int,
+  lang : @i18n.Lang,
 ) -> Html {
   div(
     class="mx-auto w-full max-w-[90rem] px-4 pb-10 pt-16 sm:px-6 lg:px-8 lg:pt-20",
@@ -104,7 +105,7 @@ fn runwasm_showcase(
         span(class="size-2 rounded-full bg-green-500", ""),
         span(
           class="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400",
-          "Install moon",
+          lang.select(en="Install moon", zh="安装 moon"),
         ),
       ],
       div(
@@ -113,17 +114,23 @@ fn runwasm_showcase(
         div(class="min-w-0") <| [
           h2(
             class="text-2xl font-bold tracking-normal text-gray-950 dark:text-slate-50",
-            "Run a published skill in one command",
+            lang.select(
+              en="Run a published skill in one command",
+              zh="一条命令运行已发布的技能",
+            ),
           ),
           p(
             class="mt-3 max-w-xl text-sm leading-6 text-gray-600 dark:text-slate-400",
-            "Install moon, pick an optimized executable entry, and run the same sandboxed command across platforms with moon runwasm.",
+            lang.select(
+              en="Install moon, pick an optimized executable entry, and run the same sandboxed command across platforms with moon runwasm.",
+              zh="安装 moon，选择优化后的可执行入口，即可通过 moon runwasm 在不同平台运行同一个沙箱命令。",
+            ),
           ),
           a(
             href="https://www.moonbitlang.com/download/",
             class="mt-5 inline-flex items-center gap-2 rounded-md border border-[#c7856b] bg-[#d79a82] px-4 py-2 text-sm font-semibold text-zinc-950 shadow-sm transition-colors hover:bg-[#e2aa94]",
           ) <| [
-            span("try now"),
+            span(lang.select(en="Try now", zh="立即尝试")),
             @svg.svg(width=16, height=16, view_box="0 0 16 16", class="size-4") <| [
               @svg.path(
                 d="M3 8h9",
@@ -168,13 +175,13 @@ fn hero_arrow() -> Html {
 }
 
 ///|
-fn skills_page(header : Html, main : Html) -> Html {
+fn skills_page(header : Html, main : Html, lang : @i18n.Lang) -> Html {
   div(class="skills-page w-full flex-col bg-white dark:bg-zinc-900") <| [
     header,
     div(class="min-h-screen flex-1") <| [
       div(class="relative flex h-full w-full flex-col", main),
     ],
-    @view.footer(),
+    @view.footer(lang),
   ]
 }
 
@@ -242,6 +249,7 @@ fn hero_feature_card(
 ///|
 fn marketplace_hero(
   entries : Status[Array[WasmEntry]],
+  lang : @i18n.Lang,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   div(
@@ -253,36 +261,53 @@ fn marketplace_hero(
       div(class="relative mx-auto max-w-5xl overflow-visible") <| [
         div(
           class="skills-hero-word pointer-events-none absolute inset-x-0 -top-8 select-none text-7xl font-black tracking-tight text-gray-100 dark:text-slate-400/10 sm:text-8xl lg:text-9xl",
-          "SKILLS",
+          lang.select(en="SKILLS", zh="技能"),
         ),
         div(
           class="relative mx-auto inline-flex items-center gap-2 rounded-full border border-gray-300 dark:border-zinc-700 bg-gray-50 dark:bg-zinc-950 px-3 py-1 font-mono text-xs uppercase tracking-wide text-gray-600 dark:text-slate-400",
         ) <| [
           span(class="size-2 rounded-full bg-mooncake2", ""),
-          span("MoonBit / Sandboxed local commands"),
+          span(
+            lang.select(
+              en="MoonBit / Sandboxed local commands",
+              zh="MoonBit / 沙箱本地命令",
+            ),
+          ),
         ],
         h1(
           class="relative mx-auto mt-5 max-w-4xl text-4xl font-bold leading-tight tracking-normal text-gray-950 dark:text-slate-50 sm:text-5xl lg:text-6xl",
-          "MoonBit Skills Marketplace",
+          lang.select(
+            en="MoonBit Skills Marketplace",
+            zh="MoonBit 技能市场",
+          ),
         ),
         p(
           class="relative mx-auto mt-4 max-w-3xl text-base leading-7 text-gray-600 dark:text-slate-400 sm:text-lg",
-          "Push a package and mooncakes.io automatically builds optimized, cross-platform executable binaries that are easy to run in a local sandbox.",
+          lang.select(
+            en="Push a package and mooncakes.io automatically builds optimized, cross-platform executable binaries that are easy to run in a local sandbox.",
+            zh="推送软件包后，mooncakes.io 会自动构建经过优化、可跨平台运行的二进制文件，方便在本地沙箱中执行。",
+          ),
         ),
         div(
           class="relative mt-6 flex flex-wrap items-center justify-center gap-2",
         ) <| [
           span(
             class="rounded-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1 text-sm text-gray-600 dark:text-slate-400 shadow-sm",
-            "\{skill_count(entries)} executable entries",
+            lang.select(
+              en="\{skill_count(entries)} executable entries",
+              zh="\{skill_count(entries)} 个可执行入口",
+            ),
           ),
           span(
             class="rounded-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1 text-sm text-gray-600 dark:text-slate-400 shadow-sm",
-            "local sandbox",
+            lang.select(en="local sandbox", zh="本地沙箱"),
           ),
           span(
             class="rounded-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1 text-sm text-gray-600 dark:text-slate-400 shadow-sm",
-            "cross-platform binaries",
+            lang.select(
+              en="cross-platform binaries",
+              zh="跨平台二进制文件",
+            ),
           ),
         ],
         div(
@@ -291,11 +316,11 @@ fn marketplace_hero(
           button(
             class="rounded-md bg-[#d79a82] px-4 py-2 text-sm font-semibold text-zinc-950 shadow-sm transition-colors hover:bg-[#e2aa94]",
             on_click=emit(ScrollToSkills),
-          ) <| span("Search Skills"),
+          ) <| span(lang.select(en="Search Skills", zh="搜索技能")),
           a(
             href="https://www.moonbitlang.com/download/",
             class="rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-4 py-2 text-sm font-semibold text-gray-900 dark:text-slate-50 shadow-sm transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-50 dark:hover:bg-zinc-950",
-            "Install moon",
+            lang.select(en="Install moon", zh="安装 moon"),
           ),
         ],
       ],
@@ -306,6 +331,7 @@ fn marketplace_hero(
 ///|
 fn source_context_section(
   entries : Status[Array[WasmEntry]],
+  lang : @i18n.Lang,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   div(class="mx-auto w-full max-w-[90rem] px-4 py-8 sm:px-6 lg:px-8") <| [
@@ -316,34 +342,49 @@ fn source_context_section(
       ),
       h2(
         class="mt-4 max-w-2xl text-2xl font-bold leading-tight tracking-normal text-gray-950 dark:text-slate-50 sm:text-3xl",
-        "Publish once, distribute safely across platforms",
+        lang.select(
+          en="Publish once, distribute safely across platforms",
+          zh="一次发布，安全分发到各个平台",
+        ),
       ),
       div(
         class="mt-4 max-w-3xl space-y-3 text-sm leading-6 text-gray-600 dark:text-slate-400",
       ) <| [
         p() <| [
-          @html.text(
-            "Under the hood, mooncakes.io compiles each skill to optimized ",
+          @html.select(
+            lang.select(
+              en="Under the hood, mooncakes.io compiles each skill to optimized ",
+              zh="mooncakes.io 会在后台把每个技能编译为经过优化的 ",
+            ),
           ),
           a(
             href="https://developer.mozilla.org/en-US/docs/WebAssembly/Guides/Concepts",
             class="font-medium text-gray-900 dark:text-slate-50 underline underline-offset-2 hover:text-[#c7856b]",
             "WebAssembly (Wasm)",
           ),
-          @html.text(
-            " binaries, then exposes them as executable commands through moon runwasm. The Wasm sandbox keeps commands isolated while the same artifact stays portable across platforms.",
+          @html.select(
+            lang.select(
+              en=" binaries, then exposes them as executable commands through moon runwasm. The Wasm sandbox keeps commands isolated while the same artifact stays portable across platforms.",
+              zh=" 二进制文件，再通过 moon runwasm 将它们作为可执行命令提供。Wasm 沙箱会隔离命令，同时让同一份产物能够跨平台运行。",
+            ),
           ),
         ],
         p(
-          "Add SKILL.md and repository links so users can inspect what a command does before they reuse it.",
+          lang.select(
+            en="Add SKILL.md and repository links so users can inspect what a command does before they reuse it.",
+            zh="添加 SKILL.md 和仓库链接，让用户在复用命令前了解它的用途。",
+          ),
         ),
       ],
       div(class="mt-6 grid gap-3 lg:grid-cols-3") <| [
         hero_feature_card(
           "01",
-          "Fast publishing",
-          "Ship a MoonBit package with SKILL.md so its executable entry is discoverable on mooncakes.io.",
-          "Publish packages",
+          lang.select(en="Fast publishing", zh="快速发布"),
+          lang.select(
+            en="Ship a MoonBit package with SKILL.md so its executable entry is discoverable on mooncakes.io.",
+            zh="发布包含 SKILL.md 的 MoonBit 软件包，让它的可执行入口能够在 mooncakes.io 上被发现。",
+          ),
+          lang.select(en="Publish packages", zh="发布软件包"),
           @config.search,
           action_href="https://docs.moonbitlang.com/en/latest/toolchain/moon/package-manage-tour.html",
           highlighted=true,
@@ -351,17 +392,26 @@ fn source_context_section(
         ),
         hero_feature_card(
           "02",
-          "Build optimized binaries",
-          "mooncakes.io automatically builds uploaded packages into Wasm binaries, then optimizes them with wasm-opt.",
-          "Browse binaries",
+          lang.select(
+            en="Build optimized binaries",
+            zh="构建优化后的二进制文件",
+          ),
+          lang.select(
+            en="mooncakes.io automatically builds uploaded packages into Wasm binaries, then optimizes them with wasm-opt.",
+            zh="mooncakes.io 会自动把上传的软件包构建成 Wasm 二进制文件，再使用 wasm-opt 进行优化。",
+          ),
+          lang.select(en="Browse binaries", zh="浏览二进制文件"),
           @config.book_open,
           emit~,
         ),
         hero_feature_card(
           "03",
-          "Share and browse skills",
-          "Share your skill with others, or browse skills published by other MoonBit users.",
-          "Browse skills",
+          lang.select(en="Share and browse skills", zh="分享和浏览技能"),
+          lang.select(
+            en="Share your skill with others, or browse skills published by other MoonBit users.",
+            zh="与其他人分享你的技能，或浏览其他 MoonBit 用户发布的技能。",
+          ),
+          lang.select(en="Browse skills", zh="浏览技能"),
           @config.download,
           emit~,
         ),
@@ -371,12 +421,18 @@ fn source_context_section(
       ) <| [
         p(
           class="max-w-2xl text-sm leading-6 text-gray-600 dark:text-slate-400",
-          "A published module gives users optimized executable binaries, SKILL.md context, and a consistent cross-platform artifact.",
+          lang.select(
+            en="A published module gives users optimized executable binaries, SKILL.md context, and a consistent cross-platform artifact.",
+            zh="发布模块后，用户可以获得经过优化的可执行文件、SKILL.md 说明以及一致的跨平台产物。",
+          ),
         ),
         div(class="flex flex-wrap gap-2") <| [
           span(
             class="inline-flex rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 font-mono text-xs font-semibold text-gray-900 dark:text-slate-50",
-            "\{skill_count(entries)} wasm entries",
+            lang.select(
+              en="\{skill_count(entries)} wasm entries",
+              zh="\{skill_count(entries)} 个 wasm 入口",
+            ),
           ),
           span(
             class="inline-flex rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 font-mono text-xs font-semibold text-gray-900 dark:text-slate-50",
@@ -384,7 +440,7 @@ fn source_context_section(
           ),
           span(
             class="inline-flex rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 font-mono text-xs font-semibold text-gray-900 dark:text-slate-50",
-            "cross-platform wasm",
+            lang.select(en="cross-platform wasm", zh="跨平台 wasm"),
           ),
         ],
       ],
@@ -396,6 +452,7 @@ fn source_context_section(
 fn sticky_search(
   filter : String,
   entries : Status[Array[WasmEntry]],
+  lang : @i18n.Lang,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   div(
@@ -413,7 +470,10 @@ fn sticky_search(
           span(class="size-2 rounded-full bg-green-500", ""),
           span(
             class="ml-1 font-mono text-xs text-gray-500 dark:text-gray-400",
-            "Type to search \{skill_count(entries)} skills",
+            lang.select(
+              en="Type to search \{skill_count(entries)} skills",
+              zh="输入内容，搜索 \{skill_count(entries)} 个技能",
+            ),
           ),
         ],
         div(class="flex items-center gap-2 px-4 py-4 font-mono text-sm") <| [
@@ -423,7 +483,10 @@ fn sticky_search(
           input(
             input_type=Text,
             value=filter,
-            placeholder="Filter skills ...",
+            placeholder=lang.select(
+              en="Filter skills ...",
+              zh="筛选技能……",
+            ),
             class="min-w-0 flex-1 bg-transparent outline-none placeholder:text-gray-400 dark:placeholder:text-slate-500",
             on_input=x => emit(FilterChanged(x)),
           ),
@@ -455,6 +518,7 @@ fn author_avatar(author : String, avatar_url : String) -> Html {
 fn entry_card(
   entry : WasmEntry,
   copied_command : String,
+  lang : @i18n.Lang,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   let skill_name = entry.name.split("/").last().unwrap().to_owned()
@@ -476,11 +540,11 @@ fn entry_card(
     "absolute right-2 top-1/2 z-20 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800"
   }
   let copy_title = if copied {
-    "Copied"
+    lang.select(en="Copied", zh="已复制")
   } else if failed {
-    "Copy failed"
+    lang.select(en="Copy failed", zh="复制失败")
   } else {
-    "Copy command"
+    lang.select(en="Copy command", zh="复制命令")
   }
   div(
     class="skills-card group flex h-full min-w-0 flex-col overflow-hidden rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-left transition-all hover:-translate-y-0.5 hover:border-gray-500 hover:shadow-xl hover:shadow-gray-300/60",
@@ -500,7 +564,7 @@ fn entry_card(
         ],
         span(
           class="shrink-0 font-mono text-[11px] text-gray-400 dark:text-slate-500",
-          @util.get_relative_time(entry.created_at),
+          @util.get_relative_time(entry.created_at, lang),
         ),
       ],
       div(class="min-h-32 flex-1 px-4 py-4") <| [
@@ -509,7 +573,10 @@ fn entry_card(
           div(
             class="min-w-0 truncate font-mono text-sm text-gray-600 dark:text-slate-400",
           ) <| [
-            span(class="text-sky-600 dark:text-sky-300", "from "),
+            span(
+              class="text-sky-600 dark:text-sky-300",
+              lang.select(en="from ", zh="来自 "),
+            ),
             span(
               class="text-emerald-700 dark:text-emerald-300",
               "\"\{entry.module_}\"",
@@ -519,7 +586,7 @@ fn entry_card(
         p(
           class="mt-4 min-h-16 line-clamp-3 text-sm leading-6 text-gray-600 dark:text-slate-400",
           if entry.description.is_empty() {
-            "No description provided."
+            lang.select(en="No description provided.", zh="暂无描述。")
           } else {
             entry.description
           },
@@ -610,11 +677,12 @@ fn list_content(
   entries : Status[Array[WasmEntry]],
   filter : String,
   copied_command : String,
+  lang : @i18n.Lang,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   match entries {
     Loading => skeleton_skill_cards(9)
-    Failed => @view.load_failed("skills")
+    Failed => @view.load_failed(lang.select(en="skills", zh="技能"), lang)
     Success(entries) => {
       let visible_entries = if filter.trim().is_empty() {
         entries
@@ -624,7 +692,7 @@ fn list_content(
       if visible_entries.is_empty() {
         div(
           class="mx-auto w-full max-w-[90rem] px-4 py-10 text-center text-sm text-gray-400 dark:text-slate-500 sm:px-6 lg:px-8",
-          "No skills found.",
+          lang.select(en="No skills found.", zh="未找到技能。"),
         )
       } else {
         div(
@@ -632,7 +700,7 @@ fn list_content(
         ) <| [
           div(
             class="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3",
-            visible_entries.map(e => entry_card(e, copied_command, emit~)),
+            visible_entries.map(e => entry_card(e, copied_command, lang, emit~)),
           ),
         ]
       }
@@ -656,26 +724,29 @@ fn list_view(
   copied_command : String,
   showcase_index : Int,
   showcase_chars : Int,
+  lang : @i18n.Lang,
   app_actions : Html,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   skills_page(
     @view.navbar(
+      lang~,
       left=skills_logo(),
       left_extra=span(
         class="rounded-full border border-gray-300/60 bg-transparent px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400",
-        "experimental",
+        lang.select(en="experimental", zh="实验性"),
       ),
       right=app_actions,
     ),
     div(class="w-full") <| [
-      marketplace_hero(entries, emit~),
+      marketplace_hero(entries, lang, emit~),
       div(id="skills", class="h-0 scroll-mt-header", ""),
-      sticky_search(filter, entries, emit~),
-      list_content(entries, filter, copied_command, emit~),
-      source_context_section(entries, emit~),
-      runwasm_showcase(entries, showcase_index, showcase_chars),
+      sticky_search(filter, entries, lang, emit~),
+      list_content(entries, filter, copied_command, lang, emit~),
+      source_context_section(entries, lang, emit~),
+      runwasm_showcase(entries, showcase_index, showcase_chars, lang),
     ],
+    lang,
   )
 }
 
@@ -706,6 +777,7 @@ fn download_filename(href : String, fallback : String) -> String {
 fn run_command_view(
   command : String,
   copied~ : Bool,
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let icon = if copied { @config.ok } else { @config.clipboard }
@@ -727,6 +799,11 @@ fn run_command_view(
       span(class="min-w-0 flex-1 break-all font-mono text-sm", command),
       button(
         class="inline-flex size-8 shrink-0 items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800",
+        title=if copied {
+          lang.select(en="Copied", zh="已复制")
+        } else {
+          lang.select(en="Copy command", zh="复制命令")
+        },
         on_click=emit(CopyRunCommand(command)),
       ) <| [
         img(class="pointer-events-none size-4 ui-icon", src=icon),
@@ -809,18 +886,25 @@ fn strip_skill_frontmatter(content : String) -> String {
 }
 
 ///|
-fn readme_content(entry : WasmEntry, readme : Status[String]) -> Html {
+fn readme_content(
+  entry : WasmEntry,
+  readme : Status[String],
+  lang : @i18n.Lang,
+) -> Html {
   match readme {
     Loading => @view.skeleton_docs_content()
     Failed | Success("") =>
       p(
         class="mt-8 text-center text-sm text-gray-400 dark:text-slate-500",
-        "\{skill_path(entry)} does not have a SKILL.md file",
+        lang.select(
+          en="\{skill_path(entry)} does not have a SKILL.md file",
+          zh="\{skill_path(entry)} 没有 SKILL.md 文件",
+        ),
       )
     Success(content) =>
       div(
         class="animate-fade-in",
-        @view.markdown(strip_skill_frontmatter(content), transform_link=href => {
+        @view.markdown(strip_skill_frontmatter(content), lang, transform_link=href => {
           skill_markdown_href(entry, href)
         }),
       )
@@ -883,9 +967,9 @@ fn metadata_link_row(label : String, href : String, value : String) -> Html {
 }
 
 ///|
-fn metadata_author_row(entry : WasmEntry) -> Html {
+fn metadata_author_row(entry : WasmEntry, lang : @i18n.Lang) -> Html {
   metadata_row(
-    "Author",
+    lang.select(en="Author", zh="作者"),
     div(class="flex min-w-0 items-center gap-2") <| [
       author_avatar(entry.author, entry.author_avatar),
       a(
@@ -905,9 +989,9 @@ fn metadata_body(rows : Array[Html]) -> Html {
 }
 
 ///|
-fn skill_files_window() -> Html {
+fn skill_files_window(lang : @i18n.Lang) -> Html {
   sidebar_window(
-    "$ files",
+    lang.select(en="$ files", zh="$ 文件"),
     div(class="px-3 py-3") <| [
       div(
         class="inline-flex rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 font-mono text-xs font-semibold text-gray-900 dark:text-slate-50",
@@ -918,9 +1002,9 @@ fn skill_files_window() -> Html {
 }
 
 ///|
-fn detail_sidebar(entry : WasmEntry) -> Html {
+fn detail_sidebar(entry : WasmEntry, lang : @i18n.Lang) -> Html {
   let package_value = if entry.package_path.is_empty() {
-    "(root)"
+    lang.select(en="(root)", zh="（根目录）")
   } else {
     entry.package_path
   }
@@ -941,43 +1025,60 @@ fn detail_sidebar(entry : WasmEntry) -> Html {
     sidebar_window(
       "$ cat moon.mod",
       metadata_body([
-        metadata_author_row(entry),
+        metadata_author_row(entry, lang),
         if entry.repository.is_empty() {
           nothing
         } else {
-          metadata_link_row("Repository", repository_href, repository_display)
+          metadata_link_row(
+            lang.select(en="Repository", zh="仓库"),
+            repository_href,
+            repository_display,
+          )
         },
-        metadata_text_row("Version", entry.version),
+        metadata_text_row(lang.select(en="Version", zh="版本"), entry.version),
       ]),
     ),
     sidebar_window(
-      "skill path",
+      lang.select(en="skill path", zh="技能路径"),
       metadata_body([
-        metadata_text_row("Module", entry.module_),
-        metadata_text_row("Package", package_value),
+        metadata_text_row(lang.select(en="Module", zh="模块"), entry.module_),
         metadata_text_row(
-          "Published",
-          @util.get_relative_time(entry.created_at),
+          lang.select(en="Package", zh="软件包"),
+          package_value,
+        ),
+        metadata_text_row(
+          lang.select(en="Published", zh="发布时间"),
+          @util.get_relative_time(entry.created_at, lang),
         ),
       ]),
     ),
     sidebar_window(
       "$ download --local",
       div(class="flex flex-col gap-3 p-4") <| [
-        action_link(entry.wasm_url, "Download wasm"),
-        action_link(entry.checksum_url, "Download checksum"),
+        action_link(
+          entry.wasm_url,
+          lang.select(en="Download wasm", zh="下载 wasm"),
+        ),
+        action_link(
+          entry.checksum_url,
+          lang.select(en="Download checksum", zh="下载校验和"),
+        ),
       ],
     ),
   ]
 }
 
 ///|
-fn copy_skill_button(readme : Status[String], emit : (Msg) -> Cmd) -> Html {
+fn copy_skill_button(
+  readme : Status[String],
+  lang : @i18n.Lang,
+  emit : (Msg) -> Cmd,
+) -> Html {
   match readme {
     Success(content) if !content.trim().is_empty() =>
       button(
         class="inline-flex size-7 shrink-0 items-center justify-center rounded border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 transition-colors hover:border-gray-400 dark:hover:border-zinc-600 hover:bg-gray-100 dark:hover:bg-zinc-900 active:bg-gray-200 dark:active:bg-gray-800",
-        title="Copy skill",
+        title=lang.select(en="Copy skill", zh="复制技能"),
         on_click=emit(CopySkill(content)),
       ) <| [
         img(class="pointer-events-none size-3.5 ui-icon", src=@config.clipboard),
@@ -990,6 +1091,7 @@ fn copy_skill_button(readme : Status[String], emit : (Msg) -> Cmd) -> Html {
 fn skill_markdown_window(
   entry : WasmEntry,
   readme : Status[String],
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   div(
@@ -1010,13 +1112,13 @@ fn skill_markdown_window(
       div(class="flex shrink-0 items-center gap-2") <| [
         span(
           class="font-mono text-[11px] text-gray-400 dark:text-slate-500",
-          "readonly",
+          lang.select(en="read-only", zh="只读"),
         ),
-        copy_skill_button(readme, emit),
+        copy_skill_button(readme, lang, emit),
       ],
     ],
     div(class="min-w-0 px-5 py-6 md:px-8") <| [
-      readme_content(entry, readme),
+      readme_content(entry, readme, lang),
     ],
   ]
 }
@@ -1026,6 +1128,7 @@ fn detail_content(
   entry : WasmEntry,
   readme : Status[String],
   command_copied~ : Bool,
+  lang : @i18n.Lang,
   emit : (Msg) -> Cmd,
 ) -> Html {
   let skill_name = entry.name.split("/").last().unwrap().to_owned()
@@ -1051,15 +1154,15 @@ fn detail_content(
             span(entry.description),
           ]
         },
-        run_command_view(run_cmd, copied=command_copied, emit),
+        run_command_view(run_cmd, copied=command_copied, lang, emit),
         div(class="mt-6 space-y-3") <| [
-          skill_files_window(),
-          skill_markdown_window(entry, readme, emit),
+          skill_files_window(lang),
+          skill_markdown_window(entry, readme, lang, emit),
         ],
       ],
       div(
         class="w-full lg:sticky lg:top-24 lg:self-start lg:shrink-0",
-        detail_sidebar(entry),
+        detail_sidebar(entry, lang),
       ),
     ],
   ]
@@ -1139,29 +1242,37 @@ fn detail_view(
   entry_status : Status[WasmEntry],
   readme : Status[String],
   command_copied~ : Bool,
+  lang : @i18n.Lang,
   app_actions : Html,
   emit~ : (Msg) -> Cmd,
 ) -> Html {
   let content = match entry_status {
     Loading => detail_loading_skeleton()
-    Failed => @view.load_failed("skill")
-    Success(entry) => detail_content(entry, readme, command_copied~, emit)
+    Failed => @view.load_failed(lang.select(en="skill", zh="技能"), lang)
+    Success(entry) => detail_content(entry, readme, command_copied~, lang, emit)
   }
   skills_page(
     @view.navbar(
+      lang~,
       left=skills_logo(),
       left_extra=span(
         class="rounded-full border border-gray-300/60 bg-transparent px-2 py-0.5 text-xs font-medium text-gray-500 dark:text-gray-400",
-        "experimental",
+        lang.select(en="experimental", zh="实验性"),
       ),
       right=app_actions,
     ),
     div(class="w-full", content),
+    lang,
   )
 }
 
 ///|
-pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
+pub fn view(
+  model : Model,
+  lang~ : @i18n.Lang,
+  app_actions~ : Html,
+  emit~ : (Msg) -> Cmd,
+) -> Html {
   match model {
     List(entries, filter~, copied_command~, showcase_index~, showcase_chars~) =>
       list_view(
@@ -1170,10 +1281,18 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
         copied_command,
         showcase_index,
         showcase_chars,
+        lang,
         app_actions,
         emit~,
       )
     Detail(entry_status, readme~, command_copied~) =>
-      detail_view(entry_status, readme, command_copied~, app_actions, emit~)
+      detail_view(
+        entry_status,
+        readme,
+        command_copied~,
+        lang,
+        app_actions,
+        emit~,
+      )
   }
 }

--- a/src/page/user/moon.pkg
+++ b/src/page/user/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
   "moonbitlang/mooncakes/view",
 }

--- a/src/page/user/pkg.generated.mbti
+++ b/src/page/user/pkg.generated.mbti
@@ -4,21 +4,22 @@ package "moonbitlang/mooncakes/page/user"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/mooncakes/util",
 }
 
 // Values
-pub fn code_frequency(@util.Status[Map[String, Int]]) -> @html.Html
+pub fn code_frequency(@util.Status[Map[String, Int]], @i18n.Lang) -> @html.Html
 
 pub fn load(String, emit~ : (Msg) -> @cmd.Cmd) -> (@cmd.Cmd, Model)
 
-pub fn profile(@util.Status[Profile]) -> @html.Html
+pub fn profile(@util.Status[Profile], @i18n.Lang) -> @html.Html
 
-pub fn published_modules(@util.Status[Array[(String, String)]]) -> @html.Html
+pub fn published_modules(@util.Status[Array[(String, String)]], @i18n.Lang) -> @html.Html
 
 pub fn update(Msg, Model) -> (@cmd.Cmd, Model)
 
-pub fn view(Model, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
+pub fn view(Model, lang~ : @i18n.Lang, app_actions~ : @html.Html, emit~ : (Msg) -> @cmd.Cmd) -> @html.Html
 
 // Errors
 

--- a/src/page/user/user.mbt
+++ b/src/page/user/user.mbt
@@ -141,9 +141,9 @@ fn suffix_after_n_chars_or(
 }
 
 ///|
-pub fn profile(profile : Status[Profile]) -> Html {
+pub fn profile(profile : Status[Profile], lang : @i18n.Lang) -> Html {
   match profile {
-    Failed => @view.load_failed("user")
+    Failed => @view.load_failed(lang.select(en="user", zh="用户信息"), lang)
     Loading => @view.skeleton_profile()
     Success({ username, avatar_url, .. }) =>
       div(class="flex flex-col items-center text-center animate-fade-in") <| [
@@ -169,21 +169,28 @@ pub fn profile(profile : Status[Profile]) -> Html {
 }
 
 ///|
-pub fn published_modules(modules : Status[PublishedModules]) -> Html {
+pub fn published_modules(
+  modules : Status[PublishedModules],
+  lang : @i18n.Lang,
+) -> Html {
   match modules {
-    Failed => @view.load_failed("published modules")
+    Failed =>
+      @view.load_failed(
+        lang.select(en="published modules", zh="已发布模块"),
+        lang,
+      )
     Loading => @view.skeleton_published_modules(6)
     Success(module_list) => {
       if module_list.length() == 0 {
         return div(
           class="p-8 text-center text-gray-500 dark:text-gray-400",
-          "No published modules yet",
+          lang.select(en="No published modules yet", zh="尚未发布模块"),
         )
       }
       div(class="animate-fade-in") <| [
         h2(
           class="text-2xl font-semibold mb-6 text-gray-800 dark:text-slate-200",
-          "Published Modules",
+          lang.select(en="Published Modules", zh="已发布模块"),
         ),
         div(
           class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4",
@@ -219,15 +226,25 @@ pub fn published_modules(modules : Status[PublishedModules]) -> Html {
 }
 
 ///|
-pub fn code_frequency(code_frequency : Status[Map[String, Int]]) -> Html {
+pub fn code_frequency(
+  code_frequency : Status[Map[String, Int]],
+  lang : @i18n.Lang,
+) -> Html {
   match code_frequency {
-    Failed => @view.load_failed("code frequency")
+    Failed =>
+      @view.load_failed(
+        lang.select(en="code frequency", zh="代码频率"),
+        lang,
+      )
     Loading => @view.skeleton_code_frequency()
     Success(data) => {
       if data.length() == 0 {
         return div(
           class="my-6 text-sm text-gray-500 dark:text-gray-400",
-          "No code frequency data",
+          lang.select(
+            en="No code frequency data",
+            zh="暂无代码频率数据",
+          ),
         )
       }
 
@@ -306,7 +323,7 @@ pub fn code_frequency(code_frequency : Status[Map[String, Int]]) -> Html {
       div(class="animate-fade-in") <| [
         h2(
           class="text-2xl font-semibold mb-6 text-gray-800 dark:text-slate-200",
-          "Code Frequency",
+          lang.select(en="Code Frequency", zh="代码频率"),
         ),
         div(
           class="bg-white dark:bg-zinc-900 rounded-xl border px-4 sm:px-6 lg:px-10 pb-6 pt-6 sm:pt-8 lg:pt-10",
@@ -349,18 +366,18 @@ pub fn code_frequency(code_frequency : Status[Map[String, Int]]) -> Html {
           div(class="flex flex-wrap gap-2 sm:gap-4 mt-4 text-xs") <| [
             div(class="flex items-center") <| [
               div(class="bg-green-500 w-4 h-2 rounded-sm mr-1", nothing),
-              text("Added"),
+              text(lang.select(en="Added", zh="新增")),
             ],
             div(class="flex items-center") <| [
               div(class="bg-red-500 w-4 h-2 rounded-sm mr-1", nothing),
-              text("Removed"),
+              text(lang.select(en="Removed", zh="删除")),
             ],
             div(class="flex items-center") <| [
               div(
                 class="bg-gray-400 dark:bg-gray-700 w-4 h-[2px] mr-1",
                 nothing,
               ),
-              text("No Change"),
+              text(lang.select(en="No Change", zh="无变化")),
             ],
           ],
         ],
@@ -370,17 +387,23 @@ pub fn code_frequency(code_frequency : Status[Map[String, Int]]) -> Html {
 }
 
 ///|
-pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
+pub fn view(
+  model : Model,
+  lang~ : @i18n.Lang,
+  app_actions~ : Html,
+  emit~ : (Msg) -> Cmd,
+) -> Html {
   ignore(emit)
   @view.page(
-    header=@view.navbar(right=app_actions),
+    lang~,
+    header=@view.navbar(lang~, right=app_actions),
     main=div(class="container lg:px-40 px-4 py-6") <| [
       // Top: User profile (centered)
-      div(class="flex justify-center mb-8", profile(model.profile)),
+      div(class="flex justify-center mb-8", profile(model.profile, lang)),
       // Content area: vertical layout
       div(class="space-y-8") <| [
         // Top: Code frequency
-        code_frequency(model.code_frequency),
+        code_frequency(model.code_frequency, lang),
         // Bottom: Published modules
         published_modules(
           match model.profile {
@@ -388,10 +411,10 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
             Loading => Loading
             Failed => Failed
           },
+          lang,
         ),
       ],
     ],
-    footer=@view.footer(),
   )
 }
 

--- a/src/util/datetime.mbt
+++ b/src/util/datetime.mbt
@@ -14,10 +14,13 @@ fn parse_plain_datetime(value : StringView) -> Int64? {
   } else {
     "\{value}T00:00:00"
   }
-  try @time.PlainDateTime::from_str(value) catch {
+  try {
+    let datetime : @time.PlainDateTime = @string.from_str(value)
+    datetime.to_unix_second()
+  } catch {
     _ => None
   } noraise {
-    value => Some(value.to_unix_second())
+    value => Some(value)
   }
 }
 
@@ -139,47 +142,81 @@ fn pluralized_ago(value : Int64, unit : String) -> String {
 }
 
 ///|
-fn relative_time_from_seconds(elapsed_seconds : Int64) -> String {
+fn relative_time_from_seconds(
+  elapsed_seconds : Int64,
+  lang : @i18n.Lang,
+) -> String {
   let seconds = if elapsed_seconds < 0L { 0L } else { elapsed_seconds }
   let minutes = seconds / 60L
   let hours = minutes / 60L
   let days = hours / 24L
   let months = days / 30L
   let years = days / 365L
-  if years > 0L {
-    if years == 1L {
-      "last year"
-    } else {
-      pluralized_ago(years, "year")
-    }
-  } else if months > 0L {
-    if months == 1L {
-      "last month"
-    } else {
-      pluralized_ago(months, "month")
-    }
-  } else if days > 0L {
-    if days == 1L {
-      "yesterday"
-    } else {
-      pluralized_ago(days, "day")
-    }
-  } else if hours > 0L {
-    pluralized_ago(hours, "hour")
-  } else if minutes > 0L {
-    pluralized_ago(minutes, "minute")
-  } else if seconds == 0L {
-    "now"
-  } else {
-    pluralized_ago(seconds, "second")
+  match lang {
+    En =>
+      if years > 0L {
+        if years == 1L {
+          "last year"
+        } else {
+          pluralized_ago(years, "year")
+        }
+      } else if months > 0L {
+        if months == 1L {
+          "last month"
+        } else {
+          pluralized_ago(months, "month")
+        }
+      } else if days > 0L {
+        if days == 1L {
+          "yesterday"
+        } else {
+          pluralized_ago(days, "day")
+        }
+      } else if hours > 0L {
+        pluralized_ago(hours, "hour")
+      } else if minutes > 0L {
+        pluralized_ago(minutes, "minute")
+      } else if seconds == 0L {
+        "now"
+      } else {
+        pluralized_ago(seconds, "second")
+      }
+    Zh =>
+      if years > 0L {
+        if years == 1L {
+          "去年"
+        } else {
+          "\{years} 年前"
+        }
+      } else if months > 0L {
+        if months == 1L {
+          "上个月"
+        } else {
+          "\{months} 个月前"
+        }
+      } else if days > 0L {
+        if days == 1L {
+          "昨天"
+        } else {
+          "\{days} 天前"
+        }
+      } else if hours > 0L {
+        "\{hours} 小时前"
+      } else if minutes > 0L {
+        "\{minutes} 分钟前"
+      } else if seconds == 0L {
+        "刚刚"
+      } else {
+        "\{seconds} 秒前"
+      }
   }
 }
 
 ///|
-pub fn get_relative_time(date : String) -> String {
+pub fn get_relative_time(date : String, lang : @i18n.Lang) -> String {
   guard iso8601_to_unix_seconds(date) is Some(date_seconds) else { return date }
   let now_seconds = @env.now().reinterpret_as_int64() / 1000L
-  relative_time_from_seconds(now_seconds - date_seconds)
+  relative_time_from_seconds(now_seconds - date_seconds, lang)
 }
 
 ///|

--- a/src/util/datetime_wbtest.mbt
+++ b/src/util/datetime_wbtest.mbt
@@ -1,0 +1,13 @@
+///|
+test "relative time follows lang" {
+  inspect(relative_time_from_seconds(0L, En), content="now")
+  inspect(relative_time_from_seconds(5L, En), content="5 seconds ago")
+  inspect(relative_time_from_seconds(86400L, En), content="yesterday")
+  inspect(relative_time_from_seconds(0L, Zh), content="刚刚")
+  inspect(relative_time_from_seconds(5L, Zh), content="5 秒前")
+  inspect(relative_time_from_seconds(60L, Zh), content="1 分钟前")
+  inspect(relative_time_from_seconds(3600L, Zh), content="1 小时前")
+  inspect(relative_time_from_seconds(86400L, Zh), content="昨天")
+  inspect(relative_time_from_seconds(2592000L, Zh), content="上个月")
+  inspect(relative_time_from_seconds(31536000L, Zh), content="去年")
+}

--- a/src/util/moon.pkg
+++ b/src/util/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbit-community/rabbita/url",
+  "moonbitlang/mooncakes/i18n",
   "moonbitlang/x/time",
 }
 

--- a/src/util/pkg.generated.mbti
+++ b/src/util/pkg.generated.mbti
@@ -4,12 +4,13 @@ package "moonbitlang/mooncakes/util"
 import {
   "moonbit-community/rabbita/url",
   "moonbitlang/core/debug",
+  "moonbitlang/mooncakes/i18n",
 }
 
 // Values
 pub fn encode_uri_component(String) -> String
 
-pub fn get_relative_time(String) -> String
+pub fn get_relative_time(String, @i18n.Lang) -> String
 
 pub fn iso8601_to_unix_seconds(String) -> Int64?
 

--- a/src/view/button.mbt
+++ b/src/view/button.mbt
@@ -37,7 +37,7 @@ pub fn[C : @html.IsChildren] button(
 pub fn icon_button(icon : String, text? : String, on_click? : Cmd) -> Html {
   let text = match text {
     None => []
-    Some(value) => [@html.text(value)]
+    Some(value) => [@html.select(value)]
   }
   button(
     class="hover:bg-gray-200 dark:hover:bg-gray-800 active:bg-gray-300 dark:active:bg-gray-700 active:translate-y-[3px] transition-transform px-2 py-1 rounded text-sm select-none text-gray-800 dark:text-slate-200",
@@ -51,7 +51,7 @@ pub fn icon_button(icon : String, text? : String, on_click? : Cmd) -> Html {
 }
 
 ///|
-pub fn theme_toggle(on_click? : Cmd) -> Html {
+pub fn theme_toggle(on_click? : Cmd, lang~ : @i18n.Lang) -> Html {
   button(
     on_click?,
     class="theme-toggle inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium transition-colors",
@@ -64,15 +64,24 @@ pub fn theme_toggle(on_click? : Cmd) -> Html {
     img(class="theme-toggle-icon theme-toggle-icon-moon", src=@config.moon_icon),
     span(
       class="sr-only theme-toggle-label theme-toggle-label-system",
-      "Using system theme. Switch to light mode.",
+      lang.select(
+        en="Using system theme. Switch to light mode.",
+        zh="当前使用系统主题。切换到浅色模式。",
+      ),
     ),
     span(
       class="sr-only theme-toggle-label theme-toggle-label-light",
-      "Using light mode. Switch to dark mode.",
+      lang.select(
+        en="Using light mode. Switch to dark mode.",
+        zh="当前使用浅色模式。切换到深色模式。",
+      ),
     ),
     span(
       class="sr-only theme-toggle-label theme-toggle-label-dark",
-      "Using dark mode. Switch to system theme.",
+      lang.select(
+        en="Using dark mode. Switch to system theme.",
+        zh="当前使用深色模式。切换到系统主题。",
+      ),
     ),
   ]
 }

--- a/src/view/footer.mbt
+++ b/src/view/footer.mbt
@@ -1,27 +1,60 @@
 ///|
-pub fn footer() -> Html {
+fn footer_content(lang : @i18n.Lang) -> Html {
   let class = "hover:text-mooncake2 transition-colors"
   div(
-    class="px-6 min-h-28 lg:mx-10 mt-5 py-10 border-t text-gray-600 dark:text-slate-400 flex flex-col md:flex-row justify-center gap-4 md:gap-8",
+    class="px-6 min-h-28 lg:mx-10 mt-5 py-10 border-t text-gray-600 dark:text-slate-400 flex flex-col items-center gap-4",
   ) <| [
-    p("Powered by MoonBit"),
-    a(href="https://github.com/moonbitlang/mooncakes.io", class~, "Site source"),
-    a(
-      href="https://github.com/moonbitlang/mooncakes.io/issues/new",
-      class~,
-      "Report issue",
-    ),
-    a(href=packages_href(), class~, "Packages"),
-    a(href=build_queue_href(), class~, "Build queue"),
-    a(href=skills_href(), class~, "Skills"),
-    a(
-      href=@config.api_url("/api/v0/modules/statistics?raw=true"),
-      class~,
-      escape=true,
-      "Statistics",
-    ),
-    p("© 2026 mooncakes.io"),
+    div(class="flex flex-col md:flex-row justify-center gap-4 md:gap-8") <| [
+      p(lang.select(en="Powered by MoonBit", zh="由 MoonBit 提供支持")),
+      a(
+        href="https://github.com/moonbitlang/mooncakes.io",
+        class~,
+        lang.select(en="Site source", zh="网站源码"),
+      ),
+      a(
+        href="https://github.com/moonbitlang/mooncakes.io/issues/new",
+        class~,
+        lang.select(en="Report issue", zh="反馈问题"),
+      ),
+      a(
+        href=packages_href(),
+        class~,
+        lang.select(en="Packages", zh="软件包"),
+      ),
+      a(
+        href=build_queue_href(),
+        class~,
+        lang.select(en="Build queue", zh="构建队列"),
+      ),
+      a(href=skills_href(), class~, lang.select(en="Skills", zh="技能")),
+      a(
+        href=@config.api_url("/api/v0/modules/statistics?raw=true"),
+        class~,
+        escape=true,
+        lang.select(en="Statistics", zh="统计"),
+      ),
+      p("© 2026 mooncakes.io"),
+    ],
+    match lang {
+      En => nothing
+      Zh =>
+        div(
+          class="text-xs text-gray-500 dark:text-slate-500 flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-4",
+        ) <| [
+          a(href=icp_filing_href(), class~, "粤ICP备2020119212号"),
+          a(
+            href=public_security_filing_href(),
+            class~,
+            "粤公网安备44030002004653",
+          ),
+        ]
+    },
   ]
+}
+
+///|
+pub fn footer(lang : @i18n.Lang) -> Html {
+  footer_content(lang)
 }
 
 ///|
@@ -37,4 +70,14 @@ fn build_queue_href() -> String {
 ///|
 fn skills_href() -> String {
   "https://skills.mooncakes.io/"
+}
+
+///|
+fn icp_filing_href() -> String {
+  "https://beian.miit.gov.cn/"
+}
+
+///|
+fn public_security_filing_href() -> String {
+  "https://beian.mps.gov.cn/#/query/webSearch?code=44030002004653"
 }

--- a/src/view/footer_wbtest.mbt
+++ b/src/view/footer_wbtest.mbt
@@ -3,4 +3,9 @@ test "footer links use canonical site origins" {
   inspect(packages_href(), content="https://mooncakes.io/")
   inspect(build_queue_href(), content="https://mooncakes.io/build-queue")
   inspect(skills_href(), content="https://skills.mooncakes.io/")
+  inspect(icp_filing_href(), content="https://beian.miit.gov.cn/")
+  inspect(
+    public_security_filing_href(),
+    content="https://beian.mps.gov.cn/#/query/webSearch?code=44030002004653",
+  )
 }

--- a/src/view/loading.mbt
+++ b/src/view/loading.mbt
@@ -267,30 +267,43 @@ pub fn skeleton_meta_sidebar() -> Html {
 }
 
 ///|
-pub fn load_failed(resource : String) -> Html {
+pub fn load_failed(resource : String, lang : @i18n.Lang) -> Html {
   div(
     class="flex flex-col items-center justify-center py-16 w-full",
     p(
       class="text-sm text-gray-400 dark:text-slate-500",
-      "Failed to load \{resource}",
+      lang.select(en="Failed to load \{resource}", zh="加载\{resource}失败"),
     ),
   )
 }
 
 ///|
-pub fn document_not_available(_path : String) -> Html {
+pub fn document_not_available(_path : String, lang : @i18n.Lang) -> Html {
   div(class="docs-state-shell") <| [
     div(class="docs-state-card docs-state-card-failed") <| [
       div(class="docs-state-header") <| [
-        h1(class="docs-state-title", "Docs unavailable"),
+        h1(
+          class="docs-state-title",
+          lang.select(en="Docs unavailable", zh="文档不可用"),
+        ),
         p(class="docs-state-summary") <| [
-          text("Documentation assets could not be loaded. "),
+          text(
+            lang.select(
+              en="Documentation assets could not be loaded. ",
+              zh="无法加载文档资源。",
+            ),
+          ),
           a(
             class="docs-state-link",
             href="https://github.com/moonbitlang/mooncakes.io/issues/new",
-            "Report it",
+            lang.select(en="Report it", zh="反馈问题"),
           ),
-          text(" if this persists."),
+          text(
+            lang.select(
+              en=" if this persists.",
+              zh="（如果问题持续出现）。",
+            ),
+          ),
         ],
       ],
     ],

--- a/src/view/markdown.mbt
+++ b/src/view/markdown.mbt
@@ -32,6 +32,7 @@ fn inline_plain_text(inline : @cmark.Inline) -> String {
 ///|
 fn image_render(
   img : @cmark.Inline,
+  lang : @i18n.Lang,
   transform_link? : (String) -> String,
 ) -> @html.Html {
   guard img is Image(img) else {
@@ -54,7 +55,12 @@ fn image_render(
       @html.img(class="my-2", src~, alt~)
     }
     { v: { reference: Inline({ v: { dest: None, .. }, .. }), .. }, .. } =>
-      @html.text("Loading image failed: invalid url")
+      @html.select(
+        lang.select(
+          en="Loading image failed: invalid URL",
+          zh="图片加载失败：链接无效",
+        ),
+      )
     { v: { reference: Ref(_), .. }, .. } => {
       println("Unsupported image reference")
       @html.nothing
@@ -65,6 +71,7 @@ fn image_render(
 ///|
 fn inline2html(
   x : @cmark.Inline,
+  lang : @i18n.Lang,
   link_defs~ : Map[String, String],
   transform_link? : (String) -> String,
 ) -> Array[@html.Html] {
@@ -80,17 +87,17 @@ fn inline2html(
         ),
       ]
     Emphasis({ v: { inline, .. }, .. }) =>
-      [@html.em(inline2html(inline, link_defs~, transform_link?))]
-    Image(_) as img => [image_render(img, transform_link?)]
+      [@html.em(inline2html(inline, lang, link_defs~, transform_link?))]
+    Image(_) as img => [image_render(img, lang, transform_link?)]
     Inlines({ v, .. }) =>
       v
-      .map(x => inline2html(x, link_defs~, transform_link?))
+      .map(x => inline2html(x, lang, link_defs~, transform_link?))
       .to_array()
       .flatten()
     Link({ v: link, .. }) =>
-      unwrap_inline_link(link, link_defs~, transform_link?)
+      unwrap_inline_link(link, lang, link_defs~, transform_link?)
     StrongEmphasis({ v: { inline, .. }, .. }) => {
-      let inline = inline2html(inline, link_defs~, transform_link?)
+      let inline = inline2html(inline, lang, link_defs~, transform_link?)
       [@html.strong(inline)]
     }
     Text({ v: str, .. }) => [inline_text(str)]
@@ -128,11 +135,12 @@ fn unique_heading_id(
 fn heading_content(
   id : String,
   inline : Array[@html.Html],
+  lang : @i18n.Lang,
 ) -> Array[@html.Html] {
   let anchor = a(
     href="#\{id}",
     class="absolute -left-5 text-gray-300 dark:text-gray-500 hover:text-gray-500 dark:hover:text-slate-400 opacity-0 group-hover/markdown-heading:opacity-100 focus:opacity-100 transition-opacity no-underline",
-    title="Link to this section",
+    title=lang.select(en="Link to this section", zh="链接到此章节"),
     "#",
   )
   [anchor, ..inline]
@@ -141,6 +149,7 @@ fn heading_content(
 ///|
 fn block2html(
   x : @cmark.Block,
+  lang : @i18n.Lang,
   small_heading~ : Bool,
   heading_anchors~ : Bool,
   link_defs~ : Map[String, String],
@@ -155,6 +164,7 @@ fn block2html(
         class="border-l-4 border-gray-400 dark:border-zinc-600 bg-gray-50 dark:bg-zinc-950 text-gray-600 dark:text-slate-400 py-2 pl-4 my-2",
         block2html(
           block,
+          lang,
           small_heading~,
           heading_anchors~,
           link_defs~,
@@ -169,6 +179,7 @@ fn block2html(
         .map(x => {
           block2html(
             x,
+            lang,
             small_heading~,
             heading_anchors~,
             link_defs~,
@@ -194,7 +205,7 @@ fn block2html(
     }
     Heading({ v: { level, inline, .. }, .. }) =>
       if small_heading {
-        let inline = inline2html(inline, link_defs~, transform_link?)
+        let inline = inline2html(inline, lang, link_defs~, transform_link?)
         match level {
           1 =>
             h3(
@@ -215,9 +226,13 @@ fn block2html(
           None
         }
         let inline = if id is Some(id) {
-          heading_content(id, inline2html(inline, link_defs~, transform_link?))
+          heading_content(
+            id,
+            inline2html(inline, lang, link_defs~, transform_link?),
+            lang,
+          )
         } else {
-          inline2html(inline, link_defs~, transform_link?)
+          inline2html(inline, lang, link_defs~, transform_link?)
         }
         let anchor_class = if heading_anchors {
           " relative scroll-mt-header group/markdown-heading"
@@ -274,6 +289,7 @@ fn block2html(
                 span(
                   block2html(
                     block,
+                    lang,
                     small_heading~,
                     heading_anchors~,
                     link_defs~,
@@ -287,6 +303,7 @@ fn block2html(
             @html.li(
               block2html(
                 block,
+                lang,
                 small_heading~,
                 heading_anchors~,
                 link_defs~,
@@ -312,7 +329,9 @@ fn block2html(
       }
     }
     Paragraph({ v: { inline, .. }, .. }) => {
-      let child = @html.span(inline2html(inline, link_defs~, transform_link?))
+      let child = @html.span(
+        inline2html(inline, lang, link_defs~, transform_link?),
+      )
       if paragraph_margin {
         div(class="mb-4 md:pr-8", child)
       } else {
@@ -337,7 +356,7 @@ fn block2html(
                 .map(x => {
                   @html.th(
                     class="border border-gray-300 dark:border-zinc-700 p-2 font-semibold",
-                    inline2html(x.0, link_defs~, transform_link?),
+                    inline2html(x.0, lang, link_defs~, transform_link?),
                   )
                 })
                 .to_array()
@@ -354,7 +373,7 @@ fn block2html(
                 .map(x => {
                   @html.td(
                     class="border border-gray-300 dark:border-zinc-700 p-2",
-                    inline2html(x.0, link_defs~, transform_link?),
+                    inline2html(x.0, lang, link_defs~, transform_link?),
                   )
                 })
                 .to_array()
@@ -400,6 +419,7 @@ fn block2html(
 ///|
 fn unwrap_inline_link(
   x : @cmark.InlineLink,
+  lang : @i18n.Lang,
   link_defs~ : Map[String, String],
   transform_link? : (String) -> String,
 ) -> Array[@html.Html] {
@@ -429,7 +449,7 @@ fn unwrap_inline_link(
             None => link
           },
           style=["display: inline-block"],
-          image_render(img, transform_link?),
+          image_render(img, lang, transform_link?),
         ),
       ]
     ({
@@ -442,11 +462,11 @@ fn unwrap_inline_link(
             Some(f) => f(link)
             None => link
           },
-          inline2html(inline, link_defs~, transform_link?),
+          inline2html(inline, lang, link_defs~, transform_link?),
         ),
       ]
     ({ text: inline, reference: Inline({ v: { dest: None, .. }, .. }) } : @cmark.InlineLink) =>
-      inline2html(inline, link_defs~, transform_link?)
+      inline2html(inline, lang, link_defs~, transform_link?)
     ({ text: inline, reference: Ref(_, _, { key, .. }) } : @cmark.InlineLink) =>
       if link_defs.get(key) is Some(url) {
         [
@@ -456,11 +476,11 @@ fn unwrap_inline_link(
               Some(f) => f(url)
               None => url
             },
-            inline2html(inline, link_defs~, transform_link?),
+            inline2html(inline, lang, link_defs~, transform_link?),
           ),
         ]
       } else {
-        inline2html(inline, link_defs~, transform_link?)
+        inline2html(inline, lang, link_defs~, transform_link?)
       }
   }
 }
@@ -468,6 +488,7 @@ fn unwrap_inline_link(
 ///|
 pub fn markdown(
   markdown : String,
+  lang : @i18n.Lang,
   small_heading? : Bool = false,
   heading_anchors? : Bool = false,
   transform_link? : (String) -> String,
@@ -486,7 +507,7 @@ pub fn markdown(
     inline_ext_default: fn(_, acc, _) { acc },
     block_ext_default: fn(_, acc, _) { acc },
     inline: fn(_, acc, inline) {
-      Fold([..acc, ..inline2html(inline, link_defs~, transform_link?)])
+      Fold([..acc, ..inline2html(inline, lang, link_defs~, transform_link?)])
     },
     block: fn(_, acc, block) {
       Fold(
@@ -494,9 +515,10 @@ pub fn markdown(
           ..acc,
           block2html(
             block,
-            link_defs~,
+            lang,
             small_heading~,
             heading_anchors~,
+            link_defs~,
             used_heading_ids~,
             transform_link?,
             paragraph_margin=true,
@@ -506,7 +528,13 @@ pub fn markdown(
     },
   }
   try folder.fold_doc([], doc) catch {
-    FolderError(msg) => text("Failed to render markdown: \{msg}")
+    FolderError(msg) =>
+      text(
+        lang.select(
+          en="Failed to render Markdown: \{msg}",
+          zh="Markdown 渲染失败：\{msg}",
+        ),
+      )
   } noraise {
     htmls =>
       div(
@@ -518,5 +546,5 @@ pub fn markdown(
 
 ///|
 test "markdown renders empty image alt without panic" {
-  ignore(markdown("![](down-start.png)"))
+  ignore(markdown("![](down-start.png)", En))
 }

--- a/src/view/moon.pkg
+++ b/src/view/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbit-community/cmark/cmark_base",
   "moonbitlang/mooncakes/util/highlight",
   "moonbitlang/mooncakes/config",
+  "moonbitlang/mooncakes/i18n",
 }
 
 supported_targets = "js+native+wasm"

--- a/src/view/navbar.mbt
+++ b/src/view/navbar.mbt
@@ -6,7 +6,8 @@ pub(all) enum NavbarStyle {
 
 ///|
 pub fn navbar(
-  left? : Html = logo(),
+  lang~ : @i18n.Lang,
+  left? : Html = logo(lang),
   left_extra? : Html,
   middle? : Html,
   right? : Html,
@@ -60,10 +61,10 @@ pub fn navbar(
 }
 
 ///|
-pub fn logo() -> Html {
+pub fn logo(lang : @i18n.Lang) -> Html {
   a(
     class="border-gray-300 dark:border-zinc-700 font-title mx-2 font-semibold flex items-center text-nowrap",
     href="/",
-    "🥮 mooncakes.io",
+    lang.select(en="🥮 mooncakes.io", zh="🥮 月饼中心仓"),
   )
 }

--- a/src/view/not_found.mbt
+++ b/src/view/not_found.mbt
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 ///|
-pub fn not_found() -> Html {
+pub fn not_found(lang : @i18n.Lang) -> Html {
   div(class="flex flex-col items-center justify-center h-screen") <| [
     h1(class="text-4xl font-bold", "404"),
-    p(class="text-lg", "Page not found"),
-    a(href="/", class="text-blue-500 dark:text-sky-300", "Go back to home"),
+    p(class="text-lg", lang.select(en="Page not found", zh="页面不存在")),
+    a(
+      href="/",
+      class="text-blue-500 dark:text-sky-300",
+      lang.select(en="Go back to home", zh="返回首页"),
+    ),
   ]
 }

--- a/src/view/page.mbt
+++ b/src/view/page.mbt
@@ -1,9 +1,11 @@
 ///|
 pub fn page(
-  header? : Html = navbar(),
+  lang~ : @i18n.Lang,
+  header? : Html = navbar(lang~),
   main? : Html,
-  footer? : Html = footer(),
+  footer? : Html,
 ) -> Html {
+  let footer = footer.unwrap_or(footer_content(lang))
   div(
     class="w-full flex-col bg-zinc-50 dark:bg-zinc-950 dark:[--sidebar-bg:var(--color-zinc-950)]",
   ) <| [

--- a/src/view/pkg.generated.mbti
+++ b/src/view/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "moonbitlang/mooncakes/view"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/mooncakes/i18n",
 }
 
 // Values
@@ -17,25 +18,25 @@ pub fn code_block(String, kind~ : CodeBlockKind, transform_link? : (String) -> S
 
 pub fn collapse(header~ : @html.Html, body~ : @html.Html, collapsed~ : Bool, toggle~ : @cmd.Cmd, caret_config? : CaretConfig) -> @html.Html
 
-pub fn document_not_available(String) -> @html.Html
+pub fn document_not_available(String, @i18n.Lang) -> @html.Html
 
-pub fn footer() -> @html.Html
+pub fn footer(@i18n.Lang) -> @html.Html
 
 pub fn icon_button(String, text? : String, on_click? : @cmd.Cmd) -> @html.Html
 
-pub fn load_failed(String) -> @html.Html
+pub fn load_failed(String, @i18n.Lang) -> @html.Html
 
 pub fn loading() -> @html.Html
 
-pub fn logo() -> @html.Html
+pub fn logo(@i18n.Lang) -> @html.Html
 
-pub fn markdown(String, small_heading? : Bool, heading_anchors? : Bool, transform_link? : (String) -> String) -> @html.Html
+pub fn markdown(String, @i18n.Lang, small_heading? : Bool, heading_anchors? : Bool, transform_link? : (String) -> String) -> @html.Html
 
-pub fn navbar(left? : @html.Html, left_extra? : @html.Html, middle? : @html.Html, right? : @html.Html, style? : NavbarStyle) -> @html.Html
+pub fn navbar(lang~ : @i18n.Lang, left? : @html.Html, left_extra? : @html.Html, middle? : @html.Html, right? : @html.Html, style? : NavbarStyle) -> @html.Html
 
-pub fn not_found() -> @html.Html
+pub fn not_found(@i18n.Lang) -> @html.Html
 
-pub fn page(header? : @html.Html, main? : @html.Html, footer? : @html.Html) -> @html.Html
+pub fn page(lang~ : @i18n.Lang, header? : @html.Html, main? : @html.Html, footer? : @html.Html) -> @html.Html
 
 pub fn skeleton_code_frequency() -> @html.Html
 
@@ -51,7 +52,7 @@ pub fn skeleton_published_modules(Int) -> @html.Html
 
 pub fn skeleton_sidebar() -> @html.Html
 
-pub fn theme_toggle(on_click? : @cmd.Cmd) -> @html.Html
+pub fn theme_toggle(on_click? : @cmd.Cmd, lang~ : @i18n.Lang) -> @html.Html
 
 // Errors
 


### PR DESCRIPTION
## Summary

- add a shared language model and select Chinese on `pkg.moonbitlang.cn`
- localize navigation, home, docs, skills, user, build queue, footer, and relative-time text
- add localization and date-rendering coverage

## Validation

- `moon check --target js` for all touched frontend packages
- `moon test --target js` for all touched frontend packages (59 passed)
- `moon fmt`
- `moon info`
- `pnpm build`

## Integration follow-up

The sibling `frontend_service` module in the parent workspace still calls `@app.app()` without the new language argument. That workspace-level adaptation is intentionally left out of this frontend-only draft.