### PR TITLE
Configure Skills host externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ moon build --target js
 npm run dev
 ```
 
-By default API requests use the same-origin `/api` path. To build with a
-different API endpoint, set `VITE_API_ENDPOINT` to the value that should
+`VITE_SKILLS_HOST` is required and selects the host that renders the Skills
+homepage. By default API requests use the same-origin `/api` path. To build
+with a different API endpoint, set `VITE_API_ENDPOINT` to the value that should
 replace `/api`:
 
 ```bash
-VITE_API_ENDPOINT=https://api.example.com/new-api npm run build
+VITE_SKILLS_HOST=skills.mooncakes.io \
+  VITE_API_ENDPOINT=https://api.example.com/new-api \
+  npm run build
 ```
 
 ## Contribution

--- a/src/app/main.mbt
+++ b/src/app/main.mbt
@@ -107,7 +107,7 @@ fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
 
 ///|
 fn route(url : @url.Url, model : Model, emit : Emit[Msg]) -> (Cmd, Model) {
-  match @util.MooncakesioPath::resolve(url) {
+  match @util.MooncakesioPath::resolve(url, @config.skills_host()) {
     Home => {
       let (cmd, page) = @home.load(emit=x => emit(GotHomeMsg(x)))
       (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Home(page) })

--- a/src/app/main.mbt
+++ b/src/app/main.mbt
@@ -107,7 +107,7 @@ fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
 
 ///|
 fn route(url : @url.Url, model : Model, emit : Emit[Msg]) -> (Cmd, Model) {
-  match @util.MooncakesioPath::resolve(url, @config.skills_host()) {
+  match @util.MooncakesioPath::resolve(url) {
     Home => {
       let (cmd, page) = @home.load(emit=x => emit(GotHomeMsg(x)))
       (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Home(page) })

--- a/src/app/main.mbt
+++ b/src/app/main.mbt
@@ -73,27 +73,27 @@ fn update(emit : Emit[Msg], msg : Msg, model : Model) -> (Cmd, Model) {
       let (cmd, page) = @home.update(msg, page_model, emit=x => {
         emit(GotHomeMsg(x))
       })
-      (cmd, { ..model, page: Home(page) })
+      (cmd, { ..model, page: Home(page), })
     }
     (GotDocsMsg(msg), Docs(page_model)) => {
       let (cmd, page) = @docs.update(msg, page_model, emit=x => {
         emit(GotDocsMsg(x))
       })
-      (cmd, { ..model, page: Docs(page) })
+      (cmd, { ..model, page: Docs(page), })
     }
     (GotUserMsg(msg), User(page_model)) => {
       let (cmd, page) = @user.update(msg, page_model)
-      (cmd, { ..model, page: User(page) })
+      (cmd, { ..model, page: User(page), })
     }
     (GotBuildQueueMsg(msg), BuildQueue(page_model)) => {
       let (cmd, page) = @build_queue.update(msg, page_model)
-      (cmd, { ..model, page: BuildQueue(page) })
+      (cmd, { ..model, page: BuildQueue(page), })
     }
     (GotSkillsMsg(msg), Skills(page_model)) => {
       let (cmd, page) = @skills.update(msg, page_model, emit=x => {
         emit(GotSkillsMsg(x))
       })
-      (cmd, { ..model, page: Skills(page) })
+      (cmd, { ..model, page: Skills(page), })
     }
     (LinkClicked(request), _) =>
       match request {
@@ -110,29 +110,29 @@ fn route(url : @url.Url, model : Model, emit : Emit[Msg]) -> (Cmd, Model) {
   match @util.MooncakesioPath::resolve(url) {
     Home => {
       let (cmd, page) = @home.load(emit=x => emit(GotHomeMsg(x)))
-      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Home(page) })
+      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Home(page), })
     }
     BuildQueue => {
       let (cmd, page) = @build_queue.load(emit=x => emit(GotBuildQueueMsg(x)))
-      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: BuildQueue(page) })
+      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: BuildQueue(page), })
     }
     SkillsList => {
       let (cmd, page) = @skills.load(emit=x => emit(GotSkillsMsg(x)))
-      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Skills(page) })
+      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Skills(page), })
     }
     SkillsDetail(entry) => {
       let (cmd, page) = @skills.load_detail(entry, emit=x => {
         emit(GotSkillsMsg(x))
       })
-      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Skills(page) })
+      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Skills(page), })
     }
     User(name) => {
       let (cmd, page) = @user.load(name.to_owned(), emit=x => {
         emit(GotUserMsg(x))
       })
-      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: User(page) })
+      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: User(page), })
     }
-    Assets(url) => (@nav.load(url.to_string()), { ..model, page: Redirect })
+    Assets(url) => (@nav.load(url.to_string()), { ..model, page: Redirect, })
     Docs(mooncakes_path, fragment~) => {
       if model.page is Docs(page_model) &&
         @docs.is_same_path(page_model, mooncakes_path) {
@@ -152,15 +152,15 @@ fn route(url : @url.Url, model : Model, emit : Emit[Msg]) -> (Cmd, Model) {
         )
         return (
           batch([cmd, @nav.scroll_to_top()]),
-          { ..model, page: Docs(page) },
+          { ..model, page: Docs(page), },
         )
       }
       let (cmd, page) = @docs.load(mooncakes_path, fragment, emit=x => {
         emit(GotDocsMsg(x))
       })
-      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Docs(page) })
+      (batch([cmd, @nav.scroll_to_top()]), { ..model, page: Docs(page), })
     }
-    NotFound(_) => (@nav.scroll_to_top(), { ..model, page: NotFound })
+    NotFound(_) => (@nav.scroll_to_top(), { ..model, page: NotFound, })
   }
 }
 
@@ -221,7 +221,7 @@ pub fn app() -> @rabbita.App {
     preference: theme_preference_from_string(initial_theme_preference()),
     system_dark: system_prefers_dark(),
   }
-  let model = { theme, page: Redirect }
+  let model = { theme, page: Redirect, }
   apply_theme_now(theme)
   @rabbita.elmish(
     model=ReactiveModel(model),

--- a/src/config/config.mbt
+++ b/src/config/config.mbt
@@ -174,6 +174,25 @@ pub fn asset_url(path : String) -> String {
 }
 
 ///|
+#cfg(target="js")
+extern "js" fn configured_skills_host() -> String =
+  #|() =>
+  #|  typeof __MOONCAKES_SKILLS_HOST__ === "undefined"
+  #|    ? ""
+  #|    : __MOONCAKES_SKILLS_HOST__
+
+///|
+#cfg(not(target="js"))
+fn configured_skills_host() -> String {
+  @env.get_env_var("MOONCAKES_SKILLS_HOST").unwrap_or("")
+}
+
+///|
+pub fn skills_host() -> String {
+  configured_skills_host()
+}
+
+///|
 fn api_url_with_endpoint(endpoint : String, path : String) -> String {
   match path {
     [.. "/api/", .. path] => "\{endpoint}/\{path.to_owned()}"

--- a/src/config/pkg.generated.mbti
+++ b/src/config/pkg.generated.mbti
@@ -64,6 +64,8 @@ pub let section_open : String
 
 pub let share : String
 
+pub fn skills_host() -> String
+
 pub let sun_icon : String
 
 pub let tag : String

--- a/src/page/build_queue/state.mbt
+++ b/src/page/build_queue/state.mbt
@@ -30,7 +30,7 @@ pub fn load(emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
     @http.get(@config.api_url("/api/v0/builds")).expect_json(r => {
       emit(GotBuilds(r))
     }),
-    { queue: Loading, recent: Loading },
+    { queue: Loading, recent: Loading, },
   )
 }
 
@@ -40,11 +40,11 @@ pub fn update(msg : Msg, _model : Model) -> (Cmd, Model) {
     GotBuilds(Ok(data)) =>
       (
         none,
-        { queue: Success(data.queued), recent: Success(data.recent_completed) },
+        { queue: Success(data.queued), recent: Success(data.recent_completed), },
       )
     GotBuilds(Err(e)) => {
       println(e)
-      (none, { queue: Failed, recent: Failed })
+      (none, { queue: Failed, recent: Failed, })
     }
   }
 }
@@ -97,7 +97,7 @@ impl @json.FromJson for BuildData with fn from_json(json : Json, path) {
           _ => raise JsonDecodeError((path, "invalid build item: \{Repr(x)}"))
         }
       }
-      { queued: queued_items, recent_completed: recent_completed_items }
+      { queued: queued_items, recent_completed: recent_completed_items, }
     }
     _ => raise JsonDecodeError((path, "invalid builds response"))
   }

--- a/src/page/docs/cards.mbt
+++ b/src/page/docs/cards.mbt
@@ -20,17 +20,17 @@ priv struct FoldedState {
 
 ///|
 fn FoldedState::new() -> FoldedState {
-  { set: @immut/sorted_set.new(), card_mode: Expanded }
+  { set: @immut/sorted_set.new(), card_mode: Expanded, }
 }
 
 ///|
 fn FoldedState::add(self : FoldedState, id : String) -> FoldedState {
-  { ..self, set: self.set.add(id) }
+  { ..self, set: self.set.add(id), }
 }
 
 ///|
 fn FoldedState::remove(self : FoldedState, id : String) -> FoldedState {
-  { ..self, set: self.set.remove(id) }
+  { ..self, set: self.set.remove(id), }
 }
 
 ///|
@@ -43,7 +43,7 @@ fn FoldedState::contains(self : FoldedState, id : String) -> Bool {
 
 ///|
 fn FoldedState::set_mode(self : FoldedState, mode : CardMode) -> FoldedState {
-  { ..self, card_mode: mode }
+  { ..self, card_mode: mode, }
 }
 
 ///|
@@ -128,7 +128,7 @@ fn impl_doc(
   module_version~ : String,
   emit : (Msg) -> Cmd,
 ) -> Html {
-  let { self_type, trait_type, methods } = doc
+  let { self_type, trait_type, methods, } = doc
   let id = doc.get_id()
   let signature : Html = pre(
     class="bg-gray-100 dark:bg-zinc-900 text-wrap pr-4",
@@ -158,7 +158,7 @@ fn type_doc(
   module_version~ : String,
   emit : (Msg) -> Cmd,
 ) -> Html {
-  let { docstring, signature, methods, impls, name: _, loc } = doc
+  let { docstring, signature, methods, impls, name: _, loc, } = doc
   let id = doc.get_id()
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div() <| [
@@ -191,7 +191,7 @@ fn trait_doc(
   module_version~ : String,
   emit : (Msg) -> Cmd,
 ) -> Html {
-  let { docstring, signature, impls, name: _, loc } = doc
+  let { docstring, signature, impls, name: _, loc, } = doc
   let id = doc.get_id()
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div() <| [
@@ -221,7 +221,7 @@ fn type_alias_doc(
   module_version~ : String,
   emit : (Msg) -> Cmd,
 ) -> Html {
-  let { name: _, docstring, signature, loc } = doc
+  let { name: _, docstring, signature, loc, } = doc
   let signature = signature_view(signature, module_name~, module_version~)
   let content = div(
     class="pl-4 mb-2",
@@ -347,7 +347,7 @@ fn value_doc(
   enable_title? : Bool = false,
   emit : (Msg) -> Cmd,
 ) -> Html {
-  let { name: _, docstring, signature, loc } = doc
+  let { name: _, docstring, signature, loc, } = doc
   let id = type_id
     .map(fn(x) { "\{x}::\{doc.get_id()}" })
     .unwrap_or(doc.get_id())
@@ -378,7 +378,7 @@ fn misc_doc(
   module_version~ : String,
   emit : (Msg) -> Cmd,
 ) -> Html {
-  let { name, methods, impls } = doc
+  let { name, methods, impls, } = doc
   let id = doc.get_id()
   let signature = div(
     id=name,
@@ -522,7 +522,9 @@ fn document(
     emit,
   )
   let doc_list = match package_data {
-    Some(Success({ traits, types, errors, typealiases, values, misc, name: _ })) => {
+    Some(
+      Success({ traits, types, errors, typealiases, values, misc, name: _, })
+    ) => {
       let count = traits.length() +
         types.length() +
         errors.length() +

--- a/src/page/docs/module_index.mbt
+++ b/src/page/docs/module_index.mbt
@@ -275,7 +275,7 @@ fn decode_type_path(
 ) -> TypePath raise @json.JsonDecodeError {
   match json {
     { "path": String(type_path), "name": String(name), .. } =>
-      { path: type_path, name }
+      { path: type_path, name, }
     _ => raise JsonDecodeError((path, "invalid json in type path"))
   }
 }
@@ -330,7 +330,7 @@ fn decode_trait_index(
   match json {
     { "name": String(name), "impls": Array(impls), .. } => {
       let impls = impls.map(x => decode_impl_index(x, path))
-      { name, impls }
+      { name, impls, }
     }
     _ => raise JsonDecodeError((path, "invalid json in trait index"))
   }
@@ -356,7 +356,7 @@ fn decode_type_index(
           _ => raise JsonDecodeError((path, "invalid json in type index"))
         }
       }
-      { name, impls, methods: decoded_methods }
+      { name, impls, methods: decoded_methods, }
     }
     _ => raise JsonDecodeError((path, "invalid json in type index"))
   }
@@ -368,7 +368,7 @@ fn decode_typealias_index(
   path : @json.JsonPath,
 ) -> TypeAliasIndex raise @json.JsonDecodeError {
   match json {
-    String(x) => { name: x }
+    String(x) => { name: x, }
     _ => raise JsonDecodeError((path, "invalid json in typealias index"))
   }
 }
@@ -379,7 +379,7 @@ fn decode_value_index(
   path : @json.JsonPath,
 ) -> ValueIndex raise @json.JsonDecodeError {
   match json {
-    String(x) => { name: x }
+    String(x) => { name: x, }
     _ => raise JsonDecodeError((path, "invalid json in value index"))
   }
 }
@@ -404,7 +404,7 @@ fn decode_misc_index(
           _ => raise JsonDecodeError((path, "invalid json in misc index"))
         }
       }
-      { name, impls, methods: decoded_methods }
+      { name, impls, methods: decoded_methods, }
     }
     _ => raise JsonDecodeError((path, "invalid json in misc index"))
   }
@@ -426,7 +426,7 @@ fn decode_impl_index(
           _ => raise JsonDecodeError((path, "invalid methods in impl index"))
         }
       }
-      { self: self_type, trait_: trait_type, methods: decoded_methods }
+      { self: self_type, trait_: trait_type, methods: decoded_methods, }
     }
     _ => raise JsonDecodeError((path, "invalid json in impl index"))
   }
@@ -457,7 +457,7 @@ fn decode_package_index(
       let typealias_ = typealias_.map(x => decode_typealias_index(x, json_path))
       let values = values.map(x => decode_value_index(x, json_path))
       let misc = miscs.map(x => decode_misc_index(x, json_path))
-      { traits, errors, types, typealias_, values, misc, path: pkg_path }
+      { traits, errors, types, typealias_, values, misc, path: pkg_path, }
     }
     _ => raise JsonDecodeError((json_path, "invalid json in package index"))
   }
@@ -478,7 +478,7 @@ fn decode_index_node(
         Null => None
         obj => Some(decode_package_index(obj, path))
       }
-      { name, pkg, childs }
+      { name, pkg, childs, }
     }
     _ => raise JsonDecodeError((path, "invalid json in index node"))
   }

--- a/src/page/docs/package_data.mbt
+++ b/src/page/docs/package_data.mbt
@@ -33,7 +33,7 @@ priv struct Loc {
 
 ///|
 test "suppress unused warnings for Loc" {
-  let dummy = { path: "", file: "", line: 0, column: 0 }
+  let dummy = { path: "", file: "", line: 0, column: 0, }
   ignore(Repr(dummy))
 }
 
@@ -98,7 +98,7 @@ fn decode_loc(
       "line": Number(line, ..),
       "column": Number(column, ..),
       ..
-    } => { path, file, line: line.to_int(), column: column.to_int() }
+    } => { path, file, line: line.to_int(), column: column.to_int(), }
     _ => raise JsonDecodeError((path, "fail to decode loc: \{Repr(json)}"))
   }
 }
@@ -113,7 +113,7 @@ fn decode_impl_doc(
       let self_type = decode_stype(self_type, path)
       let trait_type = decode_type_path(trait_type, path)
       let methods = methods.map(x => decode_value_doc(x, path))
-      { self_type, trait_type, methods }
+      { self_type, trait_type, methods, }
     }
     _ => raise JsonDecodeError((path, "fail to decode impl doc: \{Repr(json)}"))
   }
@@ -137,7 +137,7 @@ fn decode_type_doc(
       let methods = methods.map(x => decode_value_doc(x, path))
       let impls = impls.map(x => decode_impl_doc(x, path))
       let loc = decode_loc(loc, path)
-      { name, docstring, signature, methods, impls, loc }
+      { name, docstring, signature, methods, impls, loc, }
     }
     _ => raise JsonDecodeError((path, "fail to decode type doc: \{Repr(json)}"))
   }
@@ -159,7 +159,7 @@ fn decode_trait_doc(
     } => {
       let impls = impls.map(x => decode_impl_doc(x, path))
       let loc = decode_loc(loc, path)
-      { name, docstring, signature, impls, loc }
+      { name, docstring, signature, impls, loc, }
     }
     _ =>
       raise JsonDecodeError((path, "fail to decode trait doc: \{Repr(json)}"))
@@ -180,7 +180,7 @@ fn decode_typealias_doc(
       ..
     } => {
       let loc = decode_loc(loc, path)
-      { name, docstring, signature, loc }
+      { name, docstring, signature, loc, }
     }
     _ =>
       raise JsonDecodeError(
@@ -201,7 +201,7 @@ fn decode_value_doc(
       "signature": String(signature),
       "loc": loc,
       ..
-    } => { name, docstring, signature, loc: decode_loc(loc, path) }
+    } => { name, docstring, signature, loc: decode_loc(loc, path), }
     _ =>
       raise JsonDecodeError((path, "fail to decode value doc: \{Repr(json)}"))
   }
@@ -221,7 +221,7 @@ fn decode_misc_doc(
     } : Json) => {
       let methods = methods.map(x => decode_value_doc(x, path))
       let impls = impls.map(x => decode_impl_doc(x, path))
-      { name, impls, methods }
+      { name, impls, methods, }
     }
     _ => raise JsonDecodeError((path, "fail to decode misc doc: \{Repr(json)}"))
   }
@@ -255,7 +255,7 @@ impl @json.FromJson for PackageData with fn from_json(json : Json, path) {
       traits.sort_by(fn(x, y) { compare_strings(x.name, y.name) })
       types.sort_by(fn(x, y) { compare_strings(x.name, y.name) })
       errors.sort_by(fn(x, y) { compare_strings(x.name, y.name) })
-      { name, types, traits, errors, typealiases: aliases, values, misc }
+      { name, types, traits, errors, typealiases: aliases, values, misc, }
     }
     _ =>
       raise JsonDecodeError(

--- a/src/page/docs/resource.mbt
+++ b/src/page/docs/resource.mbt
@@ -267,7 +267,7 @@ impl @json.FromJson for ResourceInfo with fn from_json(json : Json, path) {
       "source_files"? : source_files,
       ..
     } =>
-      { readme_content, source_files: decode_source_files(source_files, path) }
+      { readme_content, source_files: decode_source_files(source_files, path), }
     _ => raise JsonDecodeError((path, "invalid resource.json"))
   }
 }

--- a/src/page/docs/search.mbt
+++ b/src/page/docs/search.mbt
@@ -45,8 +45,8 @@ fn load_search_entries(
     .each(x => {
       match x {
         {
-          pkg: Some({ path, traits, errors, types, typealias_, values, misc }),
-          ..,
+          pkg: Some({ path, traits, errors, types, typealias_, values, misc, }),
+          ..
         } => {
           let vpath = versioned_docs_path(path, module_name, module_version)
           results.push({
@@ -132,7 +132,7 @@ fn search(
     let score = query.score(item=entry.fullname)
     match query.split_by_matching_sections(item=entry.fullname) {
       None => None
-      Some(matching) => Some({ matching, score, entry })
+      Some(matching) => Some({ matching, score, entry, })
     }
   })
   results.sort_by(fn(a, b) { a.score - b.score })

--- a/src/page/docs/sidebar.mbt
+++ b/src/page/docs/sidebar.mbt
@@ -97,7 +97,7 @@ priv enum ItemTarget {
 fn PkgIndex::to_document_items(
   self : PkgIndex,
 ) -> Array[@tree.Tree[ItemTarget]] {
-  let { traits, errors, types, typealias_, values, misc, path } = self
+  let { traits, errors, types, typealias_, values, misc, path, } = self
   let readme_item : @tree.Tree[ItemTarget] = Item(
     id=Symbol(pkg_path=path, kind=KReadme, "readme"),
     "README",

--- a/src/page/docs/state.mbt
+++ b/src/page/docs/state.mbt
@@ -148,7 +148,7 @@ pub fn load(
       sidebar_fab: false,
       package_data: Loading,
       collapsed_docs: FoldedState::new(),
-      search: { filter: "", results: Loading },
+      search: { filter: "", results: Loading, },
       search_entries: Loading,
       install_copied: false,
       hide_large_package: true,
@@ -248,16 +248,16 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
         (true, LogIdle | LogFailed) => LogLoading
         _ => model.build_log
       }
-      (cmd, { ..model, build_log_open, build_log })
+      (cmd, { ..model, build_log_open, build_log, })
     }
     GotBuildLog(result) =>
       (
         none,
         match result {
-          Ok(log) => { ..model, build_log: LogSuccess(log) }
+          Ok(log) => { ..model, build_log: LogSuccess(log), }
           Err(err) => {
             println(err.to_string())
-            { ..model, build_log: LogFailed }
+            { ..model, build_log: LogFailed, }
           }
         },
       )
@@ -273,7 +273,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
             }
           Err(err) => {
             log_docs_error(err.to_string())
-            { ..model, readme_content: Failed, source_files: [] }
+            { ..model, readme_content: Failed, source_files: [], }
           }
         },
       )
@@ -306,7 +306,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
           }
           Err(err) => {
             log_docs_error(err.to_string())
-            { ..model, module_index: Failed }
+            { ..model, module_index: Failed, }
           }
         },
       )
@@ -324,11 +324,11 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
             .concat(misc_impls)
             .map(ImplDoc::get_id)
             .fold(init=model.collapsed_docs, FoldedState::add)
-          { ..model, collapsed_docs, package_data: Success(package_data) }
+          { ..model, collapsed_docs, package_data: Success(package_data), }
         }
         Err(err) => {
           log_docs_error(err.to_string())
-          { ..model, package_data: Failed }
+          { ..model, package_data: Failed, }
         }
       }
       (@nav.scroll_to(model.fragment), model)
@@ -339,12 +339,12 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
       } else {
         model.collapsed_docs.add(id)
       }
-      (none, { ..model, collapsed_docs: folded_items })
+      (none, { ..model, collapsed_docs: folded_items, })
     }
     DocModeChanged(card_mode) =>
       (
         none,
-        { ..model, collapsed_docs: model.collapsed_docs.set_mode(card_mode) },
+        { ..model, collapsed_docs: model.collapsed_docs.set_mode(card_mode), },
       )
     ToggleSidebarItem(id) => {
       let sidebar_collapsed = if model.sidebar_collapsed.contains(id) {
@@ -355,7 +355,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
       (none, { ..model, sidebar_collapsed, })
     }
     ClickSidebarItem(id) => {
-      let model = { ..model, sidebar_fab: false }
+      let model = { ..model, sidebar_fab: false, }
       match id {
         Group(id) => {
           // Group nodes have no package, just toggle expand/collapse
@@ -436,7 +436,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
       (none, { ..model, sidebar_collapsed, })
     }
     CollapseAllSidebar =>
-      (none, { ..model, sidebar_collapsed: @immut/sorted_set.new() })
+      (none, { ..model, sidebar_collapsed: @immut/sorted_set.new(), })
     ToggleSearchPanel(open) => {
       let cmd = if open {
         @dialog.show("search-panel")
@@ -451,7 +451,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
         Loading => Loading
         Success(indices) => Success(search(indices, filter))
       }
-      let search = { filter, results }
+      let search = { filter, results, }
       (none, { ..model, search, })
     }
     ToggleSidebarFab => {
@@ -465,12 +465,12 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
         }),
         model,
       )
-    CopyInstallSuccess => (none, { ..model, install_copied: true })
+    CopyInstallSuccess => (none, { ..model, install_copied: true, })
     CopyInstallFailed(reason) => {
       println(reason)
-      (none, { ..model, install_copied: false })
+      (none, { ..model, install_copied: false, })
     }
-    ShowLargePackage => (none, { ..model, hide_large_package: false })
+    ShowLargePackage => (none, { ..model, hide_large_package: false, })
     ClickAnchor(id) =>
       (
         batch([

--- a/src/page/docs/view.mbt
+++ b/src/page/docs/view.mbt
@@ -353,7 +353,7 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
   let resolved_meta = match model.module_meta {
     Success(meta) => {
       let meta = match model.manifest {
-        Success(manifest) => { ..meta, version: manifest.version }
+        Success(manifest) => { ..meta, version: manifest.version, }
         _ => meta
       }
       Some(meta)

--- a/src/page/home/state.mbt
+++ b/src/page/home/state.mbt
@@ -148,7 +148,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
     GotAllModule(Ok(modules)) => {
       let indices = sort_modules_by_name(modules)
       let search_index = Lazy::new(fn() { build_search_index(indices) })
-      let model = { ..model, all_modules: Success({ indices, search_index }) }
+      let model = { ..model, all_modules: Success({ indices, search_index, }), }
       let filtered_modules = if model.filter.is_empty() {
         []
       } else {
@@ -157,7 +157,7 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
       (none, { ..model, filtered_modules, })
     }
     GotHighlights(Ok(highlights)) =>
-      (none, { ..model, highlights: Success(highlights) })
+      (none, { ..model, highlights: Success(highlights), })
     GotCount(Ok(stat)) =>
       (
         none,
@@ -171,27 +171,27 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
       )
     GotAllModule(Err(err)) | GotHighlights(Err(err)) | GotCount(Err(err)) => {
       println(err.to_string())
-      (none, { ..model, all_modules: Failed })
+      (none, { ..model, all_modules: Failed, })
     }
     FilterChanged(filter) =>
       if filter.is_empty() {
-        (none, { ..model, filter, filtered_modules: [] })
+        (none, { ..model, filter, filtered_modules: [], })
       } else {
         match model.all_modules {
           Idle =>
             (
               fetch_all_modules(emit),
-              { ..model, all_modules: Loading, filter, filtered_modules: [] },
+              { ..model, all_modules: Loading, filter, filtered_modules: [], },
             )
-          Loading => (none, { ..model, filter, filtered_modules: [] })
+          Loading => (none, { ..model, filter, filtered_modules: [], })
           Success(all) => {
             let filtered_modules = filter_indices(
               filter,
               all.search_index.force(),
             )
-            (none, { ..model, filter, filtered_modules })
+            (none, { ..model, filter, filtered_modules, })
           }
-          Failed => (none, { ..model, filter, filtered_modules: [] })
+          Failed => (none, { ..model, filter, filtered_modules: [], })
         }
       }
     ToggleAllModules => {
@@ -200,9 +200,9 @@ pub fn update(msg : Msg, model : Model, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
         Idle if show =>
           (
             fetch_all_modules(emit),
-            { ..model, all_modules: Loading, show_all_modules: show },
+            { ..model, all_modules: Loading, show_all_modules: show, },
           )
-        _ => (none, { ..model, show_all_modules: show })
+        _ => (none, { ..model, show_all_modules: show, })
       }
     }
   }
@@ -376,7 +376,7 @@ fn build_search_index(
       None => 0
       Some(time) => @util.recency_penalty(time)
     }
-    { entry: mod, path, name, author, keywords, recency_penalty }
+    { entry: mod, path, name, author, keywords, recency_penalty, }
   })
   .collect()
 }

--- a/src/page/skills/pkg.generated.mbti
+++ b/src/page/skills/pkg.generated.mbti
@@ -51,6 +51,7 @@ pub(all) struct WasmEntry {
   detail_url : String
   wasm_url : String
   checksum_url : String
+  archive_url : String
   repository : String
   description : String
   created_at : String

--- a/src/page/skills/state.mbt
+++ b/src/page/skills/state.mbt
@@ -36,6 +36,7 @@ pub(all) struct WasmEntry {
   detail_url : String
   wasm_url : String
   checksum_url : String
+  archive_url : String
   repository : String
   description : String
   created_at : String
@@ -328,6 +329,7 @@ impl @json.FromJson for WasmEntry with fn from_json(json : Json, path) {
       "detail_url": String(detail_url),
       "wasm_url": String(wasm_url),
       "checksum_url": String(checksum_url),
+      "archive_url": String(archive_url),
       "repository"? : repository,
       "metadata"? : metadata,
       "created_at": String(created_at),
@@ -359,6 +361,7 @@ impl @json.FromJson for WasmEntry with fn from_json(json : Json, path) {
         detail_url,
         wasm_url,
         checksum_url,
+        archive_url,
         repository,
         description,
         created_at,

--- a/src/page/skills/view.mbt
+++ b/src/page/skills/view.mbt
@@ -644,7 +644,7 @@ fn list_content(
 fn skills_logo() -> Html {
   let host = @config.skills_host()
   a(
-    href="https://\{host}/",
+    href="//\{host}/",
     class="border-gray-300 dark:border-zinc-700 font-title mx-2 font-semibold flex items-center text-nowrap",
     "🥮 \{host}",
   )

--- a/src/page/skills/view.mbt
+++ b/src/page/skills/view.mbt
@@ -376,7 +376,7 @@ fn source_context_section(
         div(class="flex flex-wrap gap-2") <| [
           span(
             class="inline-flex rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 font-mono text-xs font-semibold text-gray-900 dark:text-slate-50",
-            "\{skill_count(entries)} wasm entries",
+            "\{skill_count(entries)} skill entries",
           ),
           span(
             class="inline-flex rounded-md border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-3 py-1.5 font-mono text-xs font-semibold text-gray-900 dark:text-slate-50",
@@ -967,6 +967,7 @@ fn detail_sidebar(entry : WasmEntry) -> Html {
       div(class="flex flex-col gap-3 p-4") <| [
         action_link(entry.wasm_url, "Download wasm"),
         action_link(entry.checksum_url, "Download checksum"),
+        action_link(entry.archive_url, "Download skills.zip"),
       ],
     ),
   ]

--- a/src/page/skills/view.mbt
+++ b/src/page/skills/view.mbt
@@ -642,10 +642,11 @@ fn list_content(
 
 ///|
 fn skills_logo() -> Html {
+  let host = @config.skills_host()
   a(
-    href="https://skills.mooncakes.io/",
+    href="https://\{host}/",
     class="border-gray-300 dark:border-zinc-700 font-title mx-2 font-semibold flex items-center text-nowrap",
-    "🥮 skills.mooncakes.io",
+    "🥮 \{host}",
   )
 }
 

--- a/src/page/skills/view_wbtest.mbt
+++ b/src/page/skills/view_wbtest.mbt
@@ -53,6 +53,7 @@ fn sample_entry(package_path : String) -> WasmEntry {
     detail_url: "",
     wasm_url: "",
     checksum_url: "",
+    archive_url: "",
     repository: "",
     description: "",
     created_at: "2026-06-10T00:00:00Z",

--- a/src/page/user/user.mbt
+++ b/src/page/user/user.mbt
@@ -33,7 +33,7 @@ impl @json.FromJson for Profile with fn from_json(json : Json, path) {
         Some(String(url)) => url
         _ => ""
       }
-      { username, avatar_url, modules: decoded_modules }
+      { username, avatar_url, modules: decoded_modules, }
     }
     _ => raise JsonDecodeError((path, "failed to decode json \{Repr(json)}"))
   }
@@ -53,7 +53,7 @@ impl @json.FromJson for CodeFrequencyResponse with fn from_json(
           _ => raise JsonDecodeError((path, "failed to decode \{Repr(v)}"))
         }
       }
-      { data: result }
+      { data: result, }
     }
     _ => raise JsonDecodeError((path, "failed to decode \{Repr(json)}"))
   }
@@ -104,7 +104,7 @@ pub fn load(username : String, emit~ : (Msg) -> Cmd) -> (Cmd, Model) {
         ),
       ).expect_json(r => emit(GotCodeFrequency(r))),
     ]),
-    { profile: Loading, code_frequency: Loading },
+    { profile: Loading, code_frequency: Loading, },
   )
 }
 
@@ -399,16 +399,16 @@ pub fn view(model : Model, app_actions~ : Html, emit~ : (Msg) -> Cmd) -> Html {
 pub fn update(msg : Msg, model : Model) -> (Cmd, Model) {
   match msg {
     GotUserProfile(Ok(profile)) =>
-      (none, { ..model, profile: Success(profile) })
-    GotCodeFrequency(Ok({ data })) =>
-      (none, { ..model, code_frequency: Success(data) })
+      (none, { ..model, profile: Success(profile), })
+    GotCodeFrequency(Ok({ data, })) =>
+      (none, { ..model, code_frequency: Success(data), })
     GotCodeFrequency(Err(err)) => {
       println(err.to_string())
-      (none, { ..model, code_frequency: Failed })
+      (none, { ..model, code_frequency: Failed, })
     }
     GotUserProfile(Err(err)) => {
       println(err.to_string())
-      (none, { ..model, profile: Failed })
+      (none, { ..model, profile: Failed, })
     }
   }
 }

--- a/src/util/lazy.mbt
+++ b/src/util/lazy.mbt
@@ -11,7 +11,7 @@ struct Lazy[T] {
 
 ///|
 pub fn[T] Lazy::new(f : () -> T) -> Lazy[T] {
-  { thunk: Thunk(f) }
+  { thunk: Thunk(f), }
 }
 
 ///|

--- a/src/util/moon.pkg
+++ b/src/util/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/core/string",
   "moonbit-community/rabbita/url",
+  "moonbitlang/mooncakes/config",
   "moonbitlang/x/time",
 }
 

--- a/src/util/mooncakesio_url.mbt
+++ b/src/util/mooncakesio_url.mbt
@@ -26,14 +26,9 @@ pub impl Show for MooncakesioPath with fn output(self, logger) {
 }
 
 ///|
-pub fn MooncakesioPath::resolve(url : @url.Url) -> Self {
+pub fn MooncakesioPath::resolve(url : @url.Url, skills_host : String) -> Self {
   match url.path.split("/").collect() {
-    ["/"] | [""] | [] =>
-      if url.host == "skills.mooncakes.io" {
-        SkillsList
-      } else {
-        Home
-      }
+    ["/"] | [""] | [] => if url.host == skills_host { SkillsList } else { Home }
     ["build-queue"] => BuildQueue
     ["user", name] => User(name)
     ["assets", ..] => Assets(url)

--- a/src/util/mooncakesio_url.mbt
+++ b/src/util/mooncakesio_url.mbt
@@ -26,9 +26,14 @@ pub impl Show for MooncakesioPath with fn output(self, logger) {
 }
 
 ///|
-pub fn MooncakesioPath::resolve(url : @url.Url, skills_host : String) -> Self {
+pub fn MooncakesioPath::resolve(url : @url.Url) -> Self {
   match url.path.split("/").collect() {
-    ["/"] | [""] | [] => if url.host == skills_host { SkillsList } else { Home }
+    ["/"] | [""] | [] =>
+      if url.host == @config.skills_host() {
+        SkillsList
+      } else {
+        Home
+      }
     ["build-queue"] => BuildQueue
     ["user", name] => User(name)
     ["assets", ..] => Assets(url)

--- a/src/util/mooncakesio_url_test.mbt
+++ b/src/util/mooncakesio_url_test.mbt
@@ -9,13 +9,16 @@ fn test_url_with_host(
   path : String,
   fragment? : String? = None,
 ) -> @url.Url {
-  { protocol: Https, host, port: None, path, query: None, fragment }
+  { protocol: Https, host, port: None, path, query: None, fragment, }
 }
+
+///|
+const TestSkillsHost = "skills.mooncakes.io"
 
 ///|
 test "resolve root" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("")),
+    @util.MooncakesioPath::resolve(test_url(""), TestSkillsHost),
     content=(
       #|home:
     ),
@@ -26,7 +29,21 @@ test "resolve root" {
 test "resolve skills host root" {
   inspect(
     @util.MooncakesioPath::resolve(
-      test_url_with_host("skills.mooncakes.io", ""),
+      test_url_with_host(TestSkillsHost, ""),
+      TestSkillsHost,
+    ),
+    content=(
+      #|skills:
+    ),
+  )
+}
+
+///|
+test "resolve externally configured skills host root" {
+  inspect(
+    @util.MooncakesioPath::resolve(
+      test_url_with_host("skills.example.test", ""),
+      "skills.example.test",
     ),
     content=(
       #|skills:
@@ -37,7 +54,7 @@ test "resolve skills host root" {
 ///|
 test "resolve build-queue" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("build-queue")),
+    @util.MooncakesioPath::resolve(test_url("build-queue"), TestSkillsHost),
     content=(
       #|build-queue
     ),
@@ -47,7 +64,7 @@ test "resolve build-queue" {
 ///|
 test "resolve skills list" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("skills")),
+    @util.MooncakesioPath::resolve(test_url("skills"), TestSkillsHost),
     content=(
       #|skills:
     ),
@@ -59,6 +76,7 @@ test "resolve skills detail" {
   inspect(
     @util.MooncakesioPath::resolve(
       test_url("skills/moonbitlang/parser@0.3.3/cmd/moonfmt"),
+      TestSkillsHost,
     ),
     content=(
       #|skills:moonbitlang/parser@0.3.3/cmd/moonfmt
@@ -69,7 +87,7 @@ test "resolve skills detail" {
 ///|
 test "resolve user" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("user/mizchi")),
+    @util.MooncakesioPath::resolve(test_url("user/mizchi"), TestSkillsHost),
     content=(
       #|user:mizchi
     ),
@@ -79,7 +97,10 @@ test "resolve user" {
 ///|
 test "resolve docs" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("docs/mizchi/mbt_rs@0.3.0")),
+    @util.MooncakesioPath::resolve(
+      test_url("docs/mizchi/mbt_rs@0.3.0"),
+      TestSkillsHost,
+    ),
     content=(
       #|docs: mizchi/mbt_rs@0.3.0, fragment: None
     ),
@@ -89,7 +110,10 @@ test "resolve docs" {
 ///|
 test "resolve docs with package path" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("docs/moonbitlang/core/builtin")),
+    @util.MooncakesioPath::resolve(
+      test_url("docs/moonbitlang/core/builtin"),
+      TestSkillsHost,
+    ),
     content=(
       #|docs: moonbitlang/core/builtin, fragment: None
     ),
@@ -101,6 +125,7 @@ test "resolve docs with fragment" {
   inspect(
     @util.MooncakesioPath::resolve(
       test_url("docs/mizchi/mbt_rs@0.3.0", fragment=Some("MyType")),
+      TestSkillsHost,
     ),
     content=(
       #|docs: mizchi/mbt_rs@0.3.0, fragment: Some("MyType")
@@ -113,6 +138,7 @@ test "resolve docs with package path and fragment" {
   inspect(
     @util.MooncakesioPath::resolve(
       test_url("docs/moonbitlang/core/builtin", fragment=Some("Array::map")),
+      TestSkillsHost,
     ),
     content=(
       #|docs: moonbitlang/core/builtin, fragment: Some("Array::map")
@@ -123,7 +149,7 @@ test "resolve docs with package path and fragment" {
 ///|
 test "resolve assets" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("assets/foo/bar")),
+    @util.MooncakesioPath::resolve(test_url("assets/foo/bar"), TestSkillsHost),
     content=(
       #|assets:assets/foo/bar
     ),
@@ -133,7 +159,7 @@ test "resolve assets" {
 ///|
 test "resolve not found" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("unknown/path")),
+    @util.MooncakesioPath::resolve(test_url("unknown/path"), TestSkillsHost),
     content=(
       #|not-found:unknown/path
     ),

--- a/src/util/mooncakesio_url_test.mbt
+++ b/src/util/mooncakesio_url_test.mbt
@@ -13,12 +13,9 @@ fn test_url_with_host(
 }
 
 ///|
-const TestSkillsHost = "skills.mooncakes.io"
-
-///|
 test "resolve root" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url(""), TestSkillsHost),
+    @util.MooncakesioPath::resolve(test_url("")),
     content=(
       #|home:
     ),
@@ -29,21 +26,7 @@ test "resolve root" {
 test "resolve skills host root" {
   inspect(
     @util.MooncakesioPath::resolve(
-      test_url_with_host(TestSkillsHost, ""),
-      TestSkillsHost,
-    ),
-    content=(
-      #|skills:
-    ),
-  )
-}
-
-///|
-test "resolve externally configured skills host root" {
-  inspect(
-    @util.MooncakesioPath::resolve(
-      test_url_with_host("skills.example.test", ""),
-      "skills.example.test",
+      test_url_with_host(@config.skills_host(), ""),
     ),
     content=(
       #|skills:
@@ -54,7 +37,7 @@ test "resolve externally configured skills host root" {
 ///|
 test "resolve build-queue" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("build-queue"), TestSkillsHost),
+    @util.MooncakesioPath::resolve(test_url("build-queue")),
     content=(
       #|build-queue
     ),
@@ -64,7 +47,7 @@ test "resolve build-queue" {
 ///|
 test "resolve skills list" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("skills"), TestSkillsHost),
+    @util.MooncakesioPath::resolve(test_url("skills")),
     content=(
       #|skills:
     ),
@@ -76,7 +59,6 @@ test "resolve skills detail" {
   inspect(
     @util.MooncakesioPath::resolve(
       test_url("skills/moonbitlang/parser@0.3.3/cmd/moonfmt"),
-      TestSkillsHost,
     ),
     content=(
       #|skills:moonbitlang/parser@0.3.3/cmd/moonfmt
@@ -87,7 +69,7 @@ test "resolve skills detail" {
 ///|
 test "resolve user" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("user/mizchi"), TestSkillsHost),
+    @util.MooncakesioPath::resolve(test_url("user/mizchi")),
     content=(
       #|user:mizchi
     ),
@@ -97,10 +79,7 @@ test "resolve user" {
 ///|
 test "resolve docs" {
   inspect(
-    @util.MooncakesioPath::resolve(
-      test_url("docs/mizchi/mbt_rs@0.3.0"),
-      TestSkillsHost,
-    ),
+    @util.MooncakesioPath::resolve(test_url("docs/mizchi/mbt_rs@0.3.0")),
     content=(
       #|docs: mizchi/mbt_rs@0.3.0, fragment: None
     ),
@@ -110,10 +89,7 @@ test "resolve docs" {
 ///|
 test "resolve docs with package path" {
   inspect(
-    @util.MooncakesioPath::resolve(
-      test_url("docs/moonbitlang/core/builtin"),
-      TestSkillsHost,
-    ),
+    @util.MooncakesioPath::resolve(test_url("docs/moonbitlang/core/builtin")),
     content=(
       #|docs: moonbitlang/core/builtin, fragment: None
     ),
@@ -125,7 +101,6 @@ test "resolve docs with fragment" {
   inspect(
     @util.MooncakesioPath::resolve(
       test_url("docs/mizchi/mbt_rs@0.3.0", fragment=Some("MyType")),
-      TestSkillsHost,
     ),
     content=(
       #|docs: mizchi/mbt_rs@0.3.0, fragment: Some("MyType")
@@ -138,7 +113,6 @@ test "resolve docs with package path and fragment" {
   inspect(
     @util.MooncakesioPath::resolve(
       test_url("docs/moonbitlang/core/builtin", fragment=Some("Array::map")),
-      TestSkillsHost,
     ),
     content=(
       #|docs: moonbitlang/core/builtin, fragment: Some("Array::map")
@@ -149,7 +123,7 @@ test "resolve docs with package path and fragment" {
 ///|
 test "resolve assets" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("assets/foo/bar"), TestSkillsHost),
+    @util.MooncakesioPath::resolve(test_url("assets/foo/bar")),
     content=(
       #|assets:assets/foo/bar
     ),
@@ -159,7 +133,7 @@ test "resolve assets" {
 ///|
 test "resolve not found" {
   inspect(
-    @util.MooncakesioPath::resolve(test_url("unknown/path"), TestSkillsHost),
+    @util.MooncakesioPath::resolve(test_url("unknown/path")),
     content=(
       #|not-found:unknown/path
     ),

--- a/src/util/pkg.generated.mbti
+++ b/src/util/pkg.generated.mbti
@@ -43,7 +43,7 @@ pub enum MooncakesioPath {
   NotFound(String)
   Assets(@url.Url)
 }
-pub fn MooncakesioPath::resolve(@url.Url, String) -> Self
+pub fn MooncakesioPath::resolve(@url.Url) -> Self
 pub impl Show for MooncakesioPath
 
 pub(all) enum Status[T] {

--- a/src/util/pkg.generated.mbti
+++ b/src/util/pkg.generated.mbti
@@ -43,7 +43,7 @@ pub enum MooncakesioPath {
   NotFound(String)
   Assets(@url.Url)
 }
-pub fn MooncakesioPath::resolve(@url.Url) -> Self
+pub fn MooncakesioPath::resolve(@url.Url, String) -> Self
 pub impl Show for MooncakesioPath
 
 pub(all) enum Status[T] {

--- a/src/view/footer.mbt
+++ b/src/view/footer.mbt
@@ -36,5 +36,5 @@ fn build_queue_href() -> String {
 
 ///|
 fn skills_href(host : String) -> String {
-  "https://\{host}/"
+  "//\{host}/"
 }

--- a/src/view/footer.mbt
+++ b/src/view/footer.mbt
@@ -13,7 +13,7 @@ pub fn footer() -> Html {
     ),
     a(href=packages_href(), class~, "Packages"),
     a(href=build_queue_href(), class~, "Build queue"),
-    a(href=skills_href(), class~, "Skills"),
+    a(href=skills_href(@config.skills_host()), class~, "Skills"),
     a(
       href=@config.api_url("/api/v0/modules/statistics?raw=true"),
       class~,
@@ -35,6 +35,6 @@ fn build_queue_href() -> String {
 }
 
 ///|
-fn skills_href() -> String {
-  "https://skills.mooncakes.io/"
+fn skills_href(host : String) -> String {
+  "https://\{host}/"
 }

--- a/src/view/footer_wbtest.mbt
+++ b/src/view/footer_wbtest.mbt
@@ -2,5 +2,8 @@
 test "footer links use canonical site origins" {
   inspect(packages_href(), content="https://mooncakes.io/")
   inspect(build_queue_href(), content="https://mooncakes.io/build-queue")
-  inspect(skills_href(), content="https://skills.mooncakes.io/")
+  inspect(
+    skills_href("skills.example.com"),
+    content="https://skills.example.com/",
+  )
 }

--- a/src/view/footer_wbtest.mbt
+++ b/src/view/footer_wbtest.mbt
@@ -2,8 +2,5 @@
 test "footer links use canonical site origins" {
   inspect(packages_href(), content="https://mooncakes.io/")
   inspect(build_queue_href(), content="https://mooncakes.io/build-queue")
-  inspect(
-    skills_href("skills.example.com"),
-    content="https://skills.example.com/",
-  )
+  inspect(skills_href("skills.example.com"), content="//skills.example.com/")
 }

--- a/src/view/markdown.mbt
+++ b/src/view/markdown.mbt
@@ -44,7 +44,7 @@ fn image_render(
         text: alt,
         reference: Inline({ v: { dest: Some({ v: src, .. }), .. }, .. }),
       },
-      ..,
+      ..
     } => {
       let alt = inline_plain_text(alt)
       let src = match transform_link {
@@ -257,7 +257,7 @@ fn block2html(
             )
         }
       }
-    List({ v: { ty: ordered, tight, items }, .. }) => {
+    List({ v: { ty: ordered, tight, items, }, .. }) => {
       let has_task = items.iter().any(fn(x) { x.v.ext_task_marker is Some(_) })
       let items = items
         .map(x => {
@@ -445,9 +445,9 @@ fn unwrap_inline_link(
           inline2html(inline, link_defs~, transform_link?),
         ),
       ]
-    ({ text: inline, reference: Inline({ v: { dest: None, .. }, .. }) } : @cmark.InlineLink) =>
+    ({ text: inline, reference: Inline({ v: { dest: None, .. }, .. }), } : @cmark.InlineLink) =>
       inline2html(inline, link_defs~, transform_link?)
-    ({ text: inline, reference: Ref(_, _, { key, .. }) } : @cmark.InlineLink) =>
+    ({ text: inline, reference: Ref(_, _, { key, .. }), } : @cmark.InlineLink) =>
       if link_defs.get(key) is Some(url) {
         [
           @html.a(

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -70,6 +70,10 @@ export default defineConfig(({ mode }) => {
       env.VITE_ASSETS_ENDPOINT ||
       'https://assets.mooncakes.io'
   )
+  const skillsHost = process.env.VITE_SKILLS_HOST || env.VITE_SKILLS_HOST
+  if (!skillsHost) {
+    throw new Error('VITE_SKILLS_HOST is required')
+  }
 
   return {
     root: 'src',
@@ -78,6 +82,7 @@ export default defineConfig(({ mode }) => {
     define: {
       __MOONCAKES_API_ENDPOINT__: JSON.stringify(apiEndpoint),
       __MOONCAKES_ASSETS_ENDPOINT__: JSON.stringify(assetsEndpoint),
+      __MOONCAKES_SKILLS_HOST__: JSON.stringify(skillsHost),
     },
     build: {
       outDir: '../dist',


### PR DESCRIPTION
## Summary
- inject the Skills host into browser builds and SSR
- remove production-domain hardcoding from routing and Skills links
- cover externally configured host routing

## Validation
- `moon check` for js/native/wasm config and util packages
- util tests on js/native/wasm
- view tests on js
- Vite production build with `VITE_SKILLS_HOST=skills.mooncakes.test`